### PR TITLE
specify all node ports

### DIFF
--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -36,7 +36,7 @@ spec:
   ports:
   - port: 80
     targetPort: 8082
-    nodePort: 30082
+    nodePort: 32082
   selector:
     k8s-app: heapster
 ---
@@ -77,8 +77,10 @@ spec:
   ports:
   - name: http
     port: 8083
+    nodePort: 32083
   - name: api
     port: 8086
+    nodePort: 32084
   selector:
     name: influxdb
 ---
@@ -116,5 +118,6 @@ spec:
   ports:
   - name: grafana
     port: 3000
+    nodePort: 32085
   selector:
     app: grafana

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -36,7 +36,7 @@ spec:
   ports:
   - port: 80
     targetPort: 8082
-    nodePort: 32082
+    nodePort: 32500
   selector:
     k8s-app: heapster
 ---
@@ -77,10 +77,10 @@ spec:
   ports:
   - name: http
     port: 8083
-    nodePort: 32083
+    nodePort: 32501
   - name: api
     port: 8086
-    nodePort: 32084
+    nodePort: 32502
   selector:
     name: influxdb
 ---
@@ -118,6 +118,6 @@ spec:
   ports:
   - name: grafana
     port: 3000
-    nodePort: 32085
+    nodePort: 32503
   selector:
     app: grafana


### PR DESCRIPTION
Ensure we don't conflict with other ports by explicitly specifying all nodeports.