### PR TITLE
heapster: use kubelet read-only-port for queries

### DIFF
--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -48,7 +48,7 @@ spec:
         command:
         - /usr/bin/dumb-init
         - /heapster
-        - --source=kubernetes:https://kubernetes.default.svc.cluster.local?kubeletPort=10250&kubeletHttps=true
+        - --source=kubernetes:https://kubernetes.default.svc.cluster.local?kubeletPort=10255
         - --sink=influxdb:http://influxdb:8086
 ---
 apiVersion: v1


### PR DESCRIPTION
As a result of securing kubelet communication on port `10250` - use default settings of using read-only-port (`10255`) over `HTTP` (related to https://github.com/gravitational/planet/pull/218)