### PR TITLE
Change mount point for influxdb config

### DIFF
--- a/images/influxdb/Dockerfile
+++ b/images/influxdb/Dockerfile
@@ -17,4 +17,4 @@ VOLUME ["/data"]
 # volume used for storing debug logs
 VOLUME ["/logs"]
 
-CMD ["/usr/bin/dumb-init", "/influxdb/influxd", "-config", "/etc/influxdb.toml"]
+CMD ["/usr/bin/dumb-init", "/influxdb/influxd", "-config", "/etc/influxdb/influxdb.toml"]

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -121,7 +121,7 @@ spec:
       - name: influxdb
         image: monitoring-influxdb:1.2.2
         volumeMounts:
-        - mountPath: /etc
+        - mountPath: /etc/influxdb
           name: influxdb-config
         - mountPath: /data
           name: influxdb-storage


### PR DESCRIPTION
I think mounting it directly under `/etc` is what's causing the error:

`MountVolume.SetUp failed for volume "kubernetes.io/configmap/a29ae791-6c09-11e7-b1e2-028f3bece152-influxdb-config" (spec.Name: "influxdb-config") pod "a29ae791-6c09-11e7-b1e2-028f3bece152" (UID: "a29ae791-6c09-11e7-b1e2-028f3bece152") with: remove /var/lib/kubelet/pods/a29ae791-6c09-11e7-b1e2-028f3bece152/volumes/kubernetes.io~configmap/influxdb-config/resolv.conf: device or resource busy`