### PR TITLE
Bump kapacitor tag

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -7,7 +7,7 @@ PWD=$(shell pwd)
 INFLUXDB_TAG  := monitoring-influxdb:1.2.2
 HEAPSTER_TAG  := monitoring-heapster:1.4.1
 GRAFANA_TAG   := monitoring-grafana:3.0.4
-KAPACITOR_TAG := monitoring-kapacitor:1.2
+KAPACITOR_TAG := monitoring-kapacitor:1.3
 TELEGRAF_TAG  := monitoring-telegraf:1.2.1
 HOOK_TAG := monitoring-hook:$(VER)
 

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -4022,7 +4022,7 @@ spec:
     spec:
       containers:
         - name: kapacitor
-          image: monitoring-kapacitor:1.2
+          image: monitoring-kapacitor:1.3
           env:
             - name: "KAPACITOR_HOSTNAME"
               value: "kapacitor.kube-system.svc.cluster.local"


### PR DESCRIPTION
This is to mitigate issues with update when the older versions of the app (3.x) had the same kapacitor image tag but did not have credentials in the configuration.

Required for https://github.com/gravitational/gravity/issues/2460