### PR TITLE
Adding overwrite to change pre-existing dashboards

### DIFF
--- a/watcher/lib/grafana.go
+++ b/watcher/lib/grafana.go
@@ -55,6 +55,7 @@ func (c *GrafanaClient) CreateDashboard(data string) error {
 
 	response, err := c.PostJSON(c.Endpoint("api", "dashboards", "db"), CreateDashboardRequest{
 		Dashboard: dashboardJSON,
+		overwrite: true,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/watcher/lib/grafana.go
+++ b/watcher/lib/grafana.go
@@ -55,7 +55,7 @@ func (c *GrafanaClient) CreateDashboard(data string) error {
 
 	response, err := c.PostJSON(c.Endpoint("api", "dashboards", "db"), CreateDashboardRequest{
 		Dashboard: dashboardJSON,
-		overwrite: true,
+		Overwrite: true,
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Adding overwrite to change pre-existing dashboards, otherwise in case the Dashboard already exists you'll get a 412 (Conflict) error