### PR TITLE
Specify security context for kapacitor/influxdb/grafana containers explicitly

### DIFF
--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -199,6 +199,8 @@ spec:
           - --mode=rollups
       - name: influxdb
         image: monitoring-influxdb:1.2.2
+        securityContext:
+          runAsUser: 0
         command:
           - /usr/bin/dumb-init
           - /influxdb/influxd
@@ -269,6 +271,8 @@ spec:
       containers:
       - name: grafana
         image: monitoring-grafana:3.0.4
+        securityContext:
+          runAsUser: 0
         env:
           - name: GF_SECURITY_ADMIN_USER
             valueFrom:
@@ -354,6 +358,8 @@ spec:
             - --mode=alerts
         - name: kapacitor
           image: monitoring-kapacitor:1.3
+          securityContext:
+            runAsUser: 0
           env:
             - name: "KAPACITOR_HOSTNAME"
               value: "kapacitor.kube-system.svc.cluster.local"


### PR DESCRIPTION
Required as part of removing hard-coded planet/1000 UID. When the cluster is configured with UID in range `2000-65535` (UID range predefined in `restricted` PSP) - for example with `20000`, the application resources might be validated against a `restricted` provider and then the containers with unspecified context will get a user assigned automatically from said range (will most likely run as UID `2000`) and containers will start failing with permission errors.

Updates https://github.com/gravitational/gravity/issues/3083.