### PR TITLE
Lele/fix rollups keywords escaping backport to 4.x

### DIFF
--- a/watcher/lib/influxdb/rollups.go
+++ b/watcher/lib/influxdb/rollups.go
@@ -118,10 +118,10 @@ func buildFunction(f Function) (string, error) {
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
-		return fmt.Sprintf("%v(%v, %v) as %v", funcName, f.Field, param, alias), nil
+		return fmt.Sprintf("%v(\"%v\", %v) as %v", funcName, f.Field, param, alias), nil
 	}
 
-	return fmt.Sprintf("%v(%v) as %v", f.Function, f.Field, alias), nil
+	return fmt.Sprintf("%v(\"%v\") as %v", f.Function, f.Field, alias), nil
 }
 
 // isCompositeFunc checks if the specified function is composite

--- a/watcher/lib/influxdb/rollups.go
+++ b/watcher/lib/influxdb/rollups.go
@@ -118,10 +118,10 @@ func buildFunction(f Function) (string, error) {
 		if err != nil {
 			return "", trace.Wrap(err)
 		}
-		return fmt.Sprintf("%v(\"%v\", %v) as %v", funcName, f.Field, param, alias), nil
+		return fmt.Sprintf(`%v("%v", %v) as %v`, funcName, f.Field, param, alias), nil
 	}
 
-	return fmt.Sprintf("%v(\"%v\") as %v", f.Function, f.Field, alias), nil
+	return fmt.Sprintf(`%v("%v") as %v`, f.Function, f.Field, alias), nil
 }
 
 // isCompositeFunc checks if the specified function is composite


### PR DESCRIPTION
Backported double quotes fix for rollup returned strings