### PR TITLE
Update rigging to upcoming 0.0.10.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,20 @@ hook:
 
 .PHONY: import
 import: package
-	-$(GRAVITY) app delete --ops-url=$(OPS_URL) $(REPOSITORY)/$(NAME):$(VERSION) \
+	-$(GRAVITY) app delete \
+		--ops-url=$(OPS_URL) \
+		$(REPOSITORY)/$(NAME):$(VERSION) \
 		--force --insecure $(EXTRA_GRAVITY_OPTIONS)
 	$(GRAVITY) app import \
 		$(IMPORT_OPTIONS) \
 		$(EXTRA_GRAVITY_OPTIONS) \
 		--include=resources --include=registry .
+
+.PHONY: tarball
+tarball: import
+	$(GRAVITY) package export \
+		--ops-url=$(OPS_URL) \
+		$(REPOSITORY)/$(NAME):$(VERSION) $(NAME)-$(VERSION).tar.gz
 
 .PHONY: clean
 clean:

--- a/images/buildbox.mk
+++ b/images/buildbox.mk
@@ -17,7 +17,7 @@ override BUILDDIR=$(ASSETS)/build
 # Configuration by convention: use TARGET as a directory name
 BINARIES=$(BUILDDIR)/$(TARGET)
 
-BBOX := quay.io/gravitational/debian-venti:go1.7.1-jessie
+BBOX := quay.io/gravitational/debian-venti:go1.9-stretch
 
 all: prepare $(BINARIES)
 

--- a/images/hook/Dockerfile
+++ b/images/hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/rig:0.0.9
+FROM quay.io/gravitational/rig:0.0.10
 
 ARG CHANGESET
 ENV RIG_CHANGESET $CHANGESET

--- a/watcher/Makefile
+++ b/watcher/Makefile
@@ -1,4 +1,4 @@
-BUILDBOX := quay.io/gravitational/debian-venti:go1.7.1-jessie
+BUILDBOX := quay.io/gravitational/debian-venti:go1.9-stretch
 BUILDDIR := $(abspath build)
 CURDIR := $(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
 DSTDIR := /gopath/src/github.com/gravitational/monitoring-app/watcher


### PR DESCRIPTION
Update build box to build with go1.9.

Requires https://github.com/gravitational/rigging/pull/44