### PR TITLE
Fix issue with access rights to k8s metrics endpoint

### DIFF
--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -5,7 +5,7 @@ metadata:
   name: monitoring
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: monitoring:metrics
@@ -28,7 +28,7 @@ roleRef:
   kind: ClusterRole
   name: monitoring:metrics
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: monitoring
@@ -69,7 +69,7 @@ rules:
       - persistentvolumeclaims
       - services
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: monitoring

--- a/resources/resources.yaml
+++ b/resources/resources.yaml
@@ -6,6 +6,29 @@ metadata:
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: monitoring:metrics
+rules:
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: monitoring:metrics
+subjects:
+- kind: ServiceAccount
+  name: monitoring
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monitoring:metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: monitoring


### PR DESCRIPTION
Fixes collecting of metrics from heapster in k8s 1.9:
```
2018-05-01T00:34:00.148387Z log-forwarder-t5tzv telegraf-85468cc87d-j67dz_kube-system_telegraf-5c64cd728c0c64273986f6f058cacc4a412a5bed871705018ef190b43fdcd34e.log {"log":"2018-05-01T00:34:00Z E! Error in plugin [inputs.prometheus]: https://kubernetes.default.svc.cluster.local/metrics returned HTTP status 403 Forbidden\n","stream":"stderr","time":"2018-05-01T00:34:00.019852487Z"}
```