### PR TITLE
Explicitely set dashboards theme for clarity

### DIFF
--- a/resources/grafana-cfg.yaml
+++ b/resources/grafana-cfg.yaml
@@ -14,3 +14,6 @@ data:
     [auth.anonymous]
     # enable anonymous access
     enabled = true
+    [users]
+    # Default UI theme ("dark" or "light")
+    default_theme = dark


### PR DESCRIPTION
Explicitely set dashboards theme for clarity, also so that it can be
easily changed through automation (eg: with sed)