### PR TITLE
Fixed templating type html->text

### DIFF
--- a/watcher/lib/influxdb/rollups.go
+++ b/watcher/lib/influxdb/rollups.go
@@ -19,7 +19,7 @@ package influxdb
 import (
 	"bytes"
 	"fmt"
-	"html/template"
+	"text/template"
 	"strconv"
 	"strings"
 


### PR DESCRIPTION
Fixed templating type html->text (on master branch) to avoid double character escaping errors