### PR TITLE
Update influxdb configuration

### DIFF
--- a/resources/influxdb.yaml
+++ b/resources/influxdb.yaml
@@ -94,8 +94,8 @@ data:
       wal-fsync-delay = "0s"
       index-version = "inmem"
       query-log-enabled = true
-      cache-max-memory-size = "1g"
-      cache-snapshot-memory-size = "25m"
+      cache-max-memory-size = 1073741824 # 1g
+      cache-snapshot-memory-size = 26214400 # 25m
       cache-snapshot-write-cold-duration = "10m"
       compact-full-write-cold-duration = "4h"
       max-concurrent-compactions = 0


### PR DESCRIPTION
Influxdb in the employed version, does not support text size values for `cache-max-memory-size` / `cache-snapshot-memory-size`.

Fixes #3612.