### PR TITLE
kevin/refresh-namespace-dropdown

### DIFF
--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -3812,7 +3812,7 @@ data:
                         }
                     ],
                     "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"namespace_name\"",
-                    "refresh": false,
+                    "refresh": true,
                     "type": "query"
                 },
                 {


### PR DESCRIPTION
It was noticed in a customer chat that new namespaces are not automatically populated by grafana, which I'm guessing is the refresh field here, which is set below for the pods.