### PR TITLE
Remove obsolete node selectors.

### DIFF
--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -41,8 +41,6 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: docker/default
     spec:
-      nodeSelector:
-        beta.kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -127,8 +125,6 @@ spec:
               secretKeyRef:
                 name: grafana
                 key: password
-      nodeSelector:
-        beta.kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/resources/nethealth/nethealth.yaml
+++ b/resources/nethealth/nethealth.yaml
@@ -135,8 +135,6 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       serviceAccountName: nethealth
-      nodeSelector:
-        beta.kubernetes.io/arch: amd64
       tolerations:
         # Tolerate all taints
         - effect: NoSchedule
@@ -170,7 +168,7 @@ spec:
             capabilities:
               drop:
               - all
-              add: 
+              add:
               - NET_RAW
           imagePullPolicy: Always
           volumeMounts:
@@ -196,7 +194,7 @@ spec:
   selector:
     k8s-app: nethealth
   ports:
-  - name: metrics 
+  - name: metrics
     protocol: TCP
     port: 9801
     targetPort: metrics

--- a/resources/prometheus/0prometheus-operator-deployment.yaml
+++ b/resources/prometheus/0prometheus-operator-deployment.yaml
@@ -36,8 +36,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-      nodeSelector:
-        beta.kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/resources/prometheus/alertmanager-alertmanager.yaml
+++ b/resources/prometheus/alertmanager-alertmanager.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   baseImage: leader.telekube.local:5000/prometheus/alertmanager
   nodeSelector:
-    beta.kubernetes.io/os: linux
     gravitational.io/k8s-role: master
   replicas: 3
   securityContext:

--- a/resources/prometheus/kube-state-metrics-deployment.yaml
+++ b/resources/prometheus/kube-state-metrics-deployment.yaml
@@ -68,7 +68,6 @@ spec:
             cpu: 100m
             memory: 150Mi
       nodeSelector:
-        beta.kubernetes.io/os: linux
         gravitational.io/k8s-role: master
       securityContext:
         runAsNonRoot: true

--- a/resources/prometheus/node-exporter-daemonset.yaml
+++ b/resources/prometheus/node-exporter-daemonset.yaml
@@ -67,8 +67,6 @@ spec:
             memory: 20Mi
       hostNetwork: true
       hostPID: true
-      nodeSelector:
-        beta.kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/resources/prometheus/prometheus-adapter-deployment.yaml
+++ b/resources/prometheus/prometheus-adapter-deployment.yaml
@@ -42,7 +42,6 @@ spec:
           name: config
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
         gravitational.io/k8s-role: master
       serviceAccountName: prometheus-adapter
       volumes:

--- a/resources/prometheus/prometheus-prometheus.yaml
+++ b/resources/prometheus/prometheus-prometheus.yaml
@@ -13,7 +13,6 @@ spec:
       port: web
   baseImage: leader.telekube.local:5000/prometheus/prometheus
   nodeSelector:
-    beta.kubernetes.io/os: linux
     gravitational.io/k8s-role: master
   replicas: 2
   resources:


### PR DESCRIPTION
In the latest Kubernetes, the label name changed from `beta.kubernetes.io/os` to `kubernetes.io/os` so half of monitoring app pods became unschedulable.

Instead of updating the label I just removed it, cause I don't see a lot of sense in having TBH. Let me know if you think it's better to update it instead.