### PR TITLE
Remove header in nethealth.yaml

### DIFF
--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -119,7 +119,7 @@ EOF
     kubectl --namespace=monitoring patch deployment influxdb -p "$(cat $TMPFILE)"
     rm $TMPFILE
 
-    for file in /var/lib/gravity/resources/nethealth/*
+    for file in /var/lib/gravity/resources/nethealth/nethealth.yaml
     do
         rig upsert -f $file --debug
     done

--- a/resources/nethealth/nethealth.yaml
+++ b/resources/nethealth/nethealth.yaml
@@ -1,13 +1,3 @@
-# Copyright 2019 Gravitational, Inc.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#    http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
@@ -168,7 +158,7 @@ spec:
             capabilities:
               drop:
               - all
-              add: 
+              add:
               - NET_RAW
           imagePullPolicy: Always
           volumeMounts:


### PR DESCRIPTION
- rigging fails to decode nethealth.yaml because of the included header.
May want to fix up rigging `Upsert` to handle this case. For now we are
removing the header from nethealth.yaml.