### PR TITLE
[6.0.x] Fix sequence overflow bug

### DIFF
--- a/resources/nethealth/nethealth.yaml
+++ b/resources/nethealth/nethealth.yaml
@@ -133,7 +133,7 @@ spec:
           operator: Exists
       containers:
         - name: nethealth
-          image: quay.io/gravitational/nethealth-dev:6.0.0-3-gfb57cbfb-dirty
+          image: quay.io/gravitational/nethealth-dev:6.3.2
           command:
             - /nethealth
           args:


### PR DESCRIPTION
Use nethealth 6.3.2 to fix sequence overflow bug.