### PR TITLE
Exclude sys_container type from CQ

### DIFF
--- a/resources/rollups.yaml
+++ b/resources/rollups.yaml
@@ -24,7 +24,8 @@ data:
             "field": "value",
             "alias": "value_mean"
           }
-        ]
+        ],
+        "where": "type <> 'sys_container'"
       },
       {
         "retention": "medium",
@@ -36,7 +37,8 @@ data:
             "field": "value",
             "alias": "value_mean"
           }
-        ]
+        ],
+        "where": "type <> 'sys_container'"
       },
       {
         "retention": "medium",
@@ -53,7 +55,8 @@ data:
             "field": "value",
             "alias": "value_mean"
           }
-        ]
+        ],
+        "where": "type <> 'sys_container'"
       },
       {
         "retention": "medium",

--- a/watcher/Makefile
+++ b/watcher/Makefile
@@ -1,4 +1,4 @@
-BUILDBOX := quay.io/gravitational/debian-venti:go1.10.8-stretch
+BUILDBOX := quay.io/gravitational/debian-venti:go1.12.17-stretch
 BUILDDIR := $(abspath build)
 CURDIR := $(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
 DSTDIR := /gopath/src/github.com/gravitational/monitoring-app/watcher

--- a/watcher/lib/influxdb/rollups.go
+++ b/watcher/lib/influxdb/rollups.go
@@ -216,7 +216,7 @@ func validateParam(funcName, param string) error {
 var (
 	// createQueryTemplate is the template for creating InfluxDB continuous query
 	createQueryTemplate = template.Must(template.New("query").Parse(
-		`create continuous query "{{.name}}" on {{.database}} begin select {{.functions}} into {{.database}}."{{.retention_into}}"."{{.measurement_into}}" from {{if .custom_from}}{{.custom_from}}{{else}}{{.database}}."{{.retention_from}}"."{{.measurement_from}}"{{end}}{{if .where}}where {{.where}}{{end}} group by {{if .custom_group_by}}{{.custom_group_by}}{{else}}*, time({{.interval}}){{end}} end`))
+		`create continuous query "{{.name}}" on {{.database}} begin select {{.functions}} into {{.database}}."{{.retention_into}}"."{{.measurement_into}}" from {{if .custom_from}}{{.custom_from}}{{else}}{{.database}}."{{.retention_from}}"."{{.measurement_from}}"{{end}}{{if .where}} where{{.where}}{{end}} group by {{if .custom_group_by}}{{.custom_group_by}}{{else}}*, time({{.interval}}){{end}} end`))
 	// deleteQueryTemplate is the template for deleting Influx continuous query
 	deleteQueryTemplate = template.Must(template.New("query").Parse(
 		`drop continuous query "{{.name}}" on {{.database}}`))

--- a/watcher/lib/influxdb/rollups.go
+++ b/watcher/lib/influxdb/rollups.go
@@ -42,6 +42,8 @@ type Rollup struct {
 	Functions []Function `json:"functions"`
 	// CustomFrom is a custom 'from' clause. Either CustomFrom or Measurement must be provided.
 	CustomFrom string `json:"custom_from,omitempty"`
+	// Where is a where clause for the rollup
+	Where string `json:"where,omitempty"`
 	// CustomGroupBy is a custom 'group by' clause
 	CustomGroupBy string `json:"custom_group_by,omitempty"`
 }
@@ -92,6 +94,7 @@ func (r *Rollup) buildCreateQuery() (string, error) {
 		"retention_from":   constants.InfluxDBRetentionPolicy,
 		"measurement_from": r.Measurement,
 		"custom_from":      r.CustomFrom,
+		"where":            r.Where,
 		"custom_group_by":  r.CustomGroupBy,
 		"interval":         constants.RetentionToInterval[r.Retention],
 	})
@@ -213,7 +216,7 @@ func validateParam(funcName, param string) error {
 var (
 	// createQueryTemplate is the template for creating InfluxDB continuous query
 	createQueryTemplate = template.Must(template.New("query").Parse(
-		`create continuous query "{{.name}}" on {{.database}} begin select {{.functions}} into {{.database}}."{{.retention_into}}"."{{.measurement_into}}" from {{if .custom_from}}{{.custom_from}}{{else}}{{.database}}."{{.retention_from}}"."{{.measurement_from}}"{{end}} group by {{if .custom_group_by}}{{.custom_group_by}}{{else}}*, time({{.interval}}){{end}} end`))
+		`create continuous query "{{.name}}" on {{.database}} begin select {{.functions}} into {{.database}}."{{.retention_into}}"."{{.measurement_into}}" from {{if .custom_from}}{{.custom_from}}{{else}}{{.database}}."{{.retention_from}}"."{{.measurement_from}}"{{end}}{{if .where}}where {{.where}}{{end}} group by {{if .custom_group_by}}{{.custom_group_by}}{{else}}*, time({{.interval}}){{end}} end`))
 	// deleteQueryTemplate is the template for deleting Influx continuous query
 	deleteQueryTemplate = template.Must(template.New("query").Parse(
 		`drop continuous query "{{.name}}" on {{.database}}`))


### PR DESCRIPTION
* Implement where clause for rollups definition.
Exclude sys_container type from memory and cpu continuous queries to
prevent memory leak when CronJobs are used.
Fixes https://github.com/gravitational/gravity/issues/1332.