### PR TITLE
Bump nethealth

### DIFF
--- a/resources/nethealth/nethealth.yaml
+++ b/resources/nethealth/nethealth.yaml
@@ -133,7 +133,7 @@ spec:
           operator: Exists
       containers:
         - name: nethealth
-          image: quay.io/gravitational/nethealth-dev:6.3.2
+          image: quay.io/gravitational/nethealth-dev:7.1.0
           command:
             - /nethealth
           args:


### PR DESCRIPTION
### Description
This PR bumps nethealth to 7.1.0.
- Nethealth now removes stale Prometheus metrics https://github.com/gravitational/satellite/pull/197.
- Nethealth image now uses distroless base image https://github.com/gravitational/satellite/pull/198.