### PR TITLE
[6.0.x] Backport changes from master

### DIFF
--- a/images/grafana/Dockerfile
+++ b/images/grafana/Dockerfile
@@ -1,6 +1,11 @@
 ARG GRAFANA_VERSION
 FROM grafana/grafana:${GRAFANA_VERSION}
 
+# Ensure nsswitch is set so localhost will be resolved locally
+# https://github.com/gravitational/gravity/issues/1046
+# https://github.com/golang/go/issues/35305
+RUN test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
+
 COPY run.sh /run.sh
 
 EXPOSE 3000

--- a/images/hook/Dockerfile
+++ b/images/hook/Dockerfile
@@ -1,5 +1,10 @@
 FROM quay.io/gravitational/rig:6.0.3
 
+# Ensure nsswitch is set so localhost will be resolved locally
+# https://github.com/gravitational/gravity/issues/1046
+# https://github.com/golang/go/issues/35305
+RUN test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
+
 ARG CHANGESET
 ENV RIG_CHANGESET $CHANGESET
 

--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -5,36 +5,23 @@ echo "---> Assuming changeset from the environment: $RIG_CHANGESET"
 # note that rig does not take explicit changeset ID
 # taking it from the environment variables
 if [ $1 = "update" ]; then
-    echo "---> Checking: $RIG_CHANGESET"
-    if rig status $RIG_CHANGESET --retry-attempts=1 --retry-period=1s; then exit 0; fi
-
-    echo "---> Starting update, changeset: $RIG_CHANGESET"
-    rig cs delete --force -c cs/$RIG_CHANGESET
-
     echo "---> Deleting old 'heapster' resources"
     rig delete deployments/heapster --resource-namespace=monitoring --force
 
     echo "---> Deleting old 'influxdb' resources"
     rig delete deployments/influxdb --resource-namespace=monitoring --force
 
-    echo "---> Deleting old 'grafana' resources"
-    rig delete deployments/grafana --resource-namespace=monitoring --force
-
     echo "---> Deleting old 'telegraf' resources"
     rig delete deployments/telegraf --resource-namespace=monitoring --force
     rig delete daemonsets/telegraf-node --resource-namespace=monitoring --force
+    rig delete daemonsets/telegraf-node-worker --resource-namespace=monitoring --force
+    rig delete daemonsets/telegraf-node-master --resource-namespace=monitoring --force
 
     echo "---> Deleting old deployment 'kapacitor'"
     rig delete deployments/kapacitor --resource-namespace=monitoring --force
 
-    echo "---> Deleting old secrets"
-    for secret in grafana grafana-influxdb-creds smtp-configuration
-    do
-        rig delete secrets/$secret --resource-namespace=monitoring --force
-    done
-
     echo "---> Deleting old configmaps"
-    for configmap in influxdb grafana-cfg grafana grafana-dashboards-cfg grafana-dashboards grafana-datasources kapacitor-alerts rollups-default alerting-addresses
+    for configmap in influxdb grafana kapacitor-alerts rollups-default 
     do
         rig delete configmaps/$configmap --resource-namespace=monitoring --force
     done

--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -47,6 +47,10 @@ if [ $1 = "update" ]; then
         rig upsert -f $file --debug
     done
 
+    # Generate password for Grafana administrator
+    password=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | tr -d '\n ' | /opt/bin/base64)
+    sed -i s/cGFzc3dvcmQtZ29lcy1oZXJlCg==/$password/g /var/lib/gravity/resources/grafana.yaml
+
     echo "---> Creating or updating resources"
     for name in security grafana watcher
     do

--- a/images/mta/Dockerfile
+++ b/images/mta/Dockerfile
@@ -1,5 +1,10 @@
 FROM quay.io/gravitational/debian-grande:stretch
 
+# Ensure nsswitch is set so localhost will be resolved locally
+# https://github.com/gravitational/gravity/issues/1046
+# https://github.com/golang/go/issues/35305
+RUN test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
+
 RUN apt-get update && \
     apt-get install -y exim4-daemon-light && \
     apt-get clean && \

--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -62,6 +62,17 @@ spec:
         ports:
         - containerPort: 3000
           name: http
+        env:
+          - name: GF_SECURITY_ADMIN_USER
+            valueFrom:
+              secretKeyRef:
+                name: grafana
+                key: username
+          - name: GF_SECURITY_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: grafana
+                key: password
         readinessProbe:
           httpGet:
             path: /api/health
@@ -8494,33 +8505,23 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboard-nethealth
   namespace: monitoring
-  labels:
-    monitoring: dashboard
 data:
   nethealth.json: |
     {
       "annotations": {
         "list": [
-          {
-            "builtIn": 1,
-            "datasource": "prometheus",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-          }
+
         ]
       },
       "description": "Overlay network health tests",
-      "editable": true,
+      "editable": false,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 4,
+      "id": null,
       "links": [],
       "panels": [
         {
-          "datasource": "prometheus",
+          "datasource": "$datasource",
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -8614,7 +8615,7 @@ data:
           }
         },
         {
-          "datasource": "prometheus",
+          "datasource": "$datasource",
           "aliasColors": {},
           "bars": false,
           "cacheTimeout": null,
@@ -8716,7 +8717,24 @@ data:
         "network"
       ],
       "templating": {
-        "list": []
+          "list": [
+              {
+                  "current": {
+                      "text": "Prometheus",
+                      "value": "Prometheus"
+                  },
+                  "hide": 0,
+                  "label": null,
+                  "name": "datasource",
+                  "options": [
+
+                  ],
+                  "query": "prometheus",
+                  "refresh": 1,
+                  "regex": "",
+                  "type": "datasource"
+              }
+          ]
       },
       "time": {
         "from": "now-1h",

--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -15,6 +15,9 @@ data:
     [auth.anonymous]
     # enable anonymous access
     enabled = true
+    [analytics]
+    reporting_enabled = false
+    check_for_updates = false
     [users]
     # Default UI theme ("dark" or "light")
     default_theme = light

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -7,6 +7,10 @@ do
     head -n -6 $file | /opt/bin/kubectl apply -f -
 done
 
+# Generate password for Grafana administrator
+password=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | tr -d '\n ' | /opt/bin/base64)
+sed -i s/cGFzc3dvcmQtZ29lcy1oZXJlCg==/$password/g /var/lib/gravity/resources/grafana.yaml
+
 for name in security grafana watcher
 do
     /opt/bin/kubectl apply -f /var/lib/gravity/resources/${name}.yaml

--- a/watcher/Dockerfile
+++ b/watcher/Dockerfile
@@ -1,4 +1,10 @@
 FROM quay.io/gravitational/debian-tall:stretch
+
+# Ensure nsswitch is set so localhost will be resolved locally
+# https://github.com/gravitational/gravity/issues/1046
+# https://github.com/golang/go/issues/35305
+RUN test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
+
 ADD Dockerfile /
 ADD build/watcher /
 ENTRYPOINT ["/usr/bin/dumb-init", "/watcher"]


### PR DESCRIPTION
## Testing done
- [x] Checked containers for existence of `/etc/nsswitch.conf` file.
- [x] Checked nethealth metrics for removed node also removed as in PR https://github.com/gravitational/satellite/pull/197.
- [x] Checked configuration for Grafana. Analytics are disabled.
- [x] Checked possibility to add custom dashboard.

All testing is done for 6.1.29+dev. Should work the same for 6.3.x.