### PR TITLE
Bump grafana version

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all heapster heapster-build heapster-clean influxdb influxdb-build \
 	influxdb-clean grafana kapacitor telegraf deploy
 
-GRAFANA_VERSION := 5.4.5
+GRAFANA_VERSION := 6.7.4
 # TODO: heapster is marked as deprecated project and will be removed in k8s 1.13
 # https://github.com/kubernetes/heapster/blob/master/docs/deprecation.md
 HEAPSTER_VERSION := 1.5.4

--- a/images/grafana/Dockerfile
+++ b/images/grafana/Dockerfile
@@ -1,3 +1,4 @@
+# Mostly copied from https://github.com/grafana/grafana/blob/v6.7.x/packaging/docker/ubuntu.Dockerfile
 FROM debian:stretch-slim
 
 ARG GRAFANA_VERSION
@@ -46,6 +47,8 @@ RUN set -ex && groupadd -r -g $GF_GID grafana && \
              "$GF_PATHS_LOGS" \
              "$GF_PATHS_PLUGINS" \
              "$GF_PATHS_DATA" && \
+    cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" && \
+    cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml && \
     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
     chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 

--- a/images/grafana/Dockerfile
+++ b/images/grafana/Dockerfile
@@ -31,7 +31,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN set -ex && apt-get update && apt-get install -qq -y libfontconfig ca-certificates gettext-base && \
+RUN set -ex && apt-get update && apt-get install -qq -y libfontconfig ca-certificates dumb-init && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -42,15 +42,16 @@ RUN set -ex && groupadd -r -g $GF_GID grafana && \
     useradd -r -u $GF_UID -g grafana grafana && \
     mkdir -p "$GF_PATHS_PROVISIONING/datasources" \
              "$GF_PATHS_PROVISIONING/dashboards" \
+             "$GF_PATHS_PROVISIONING/notifiers" \
              "$GF_PATHS_LOGS" \
              "$GF_PATHS_PLUGINS" \
              "$GF_PATHS_DATA" && \
     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" && \
-    chmod 777 "$GF_PATHS_DATA" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS"
+    chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 
 EXPOSE 3000
 
 COPY ./run.sh /run.sh
 
 USER grafana
-ENTRYPOINT [ "/run.sh" ]
+ENTRYPOINT [  "/usr/bin/dumb-init", "/run.sh" ]

--- a/images/grafana/rootfs/var/lib/grafana/dashboards/cluster.json
+++ b/images/grafana/rootfs/var/lib/grafana/dashboards/cluster.json
@@ -4872,7 +4872,7 @@
 },
 "timezone": "browser",
 "title": "Cluster",
-"uid": "sS2fy3FWk",
+"uid": "default",
 "version": 17
 }
 

--- a/images/grafana/run.sh
+++ b/images/grafana/run.sh
@@ -1,5 +1,90 @@
-#!/bin/bash
+#!/bin/bash -e
+## Copied from https://github.com/grafana/grafana/blob/v6.7.x/packaging/docker/run.sh
 
-set -m
-echo "Starting Grafana"
-/usr/share/grafana/bin/grafana-server --config=/etc/grafana/cfg/grafana.ini
+PERMISSIONS_OK=0
+
+if [ ! -r "$GF_PATHS_CONFIG" ]; then
+    echo "GF_PATHS_CONFIG='$GF_PATHS_CONFIG' is not readable."
+    PERMISSIONS_OK=1
+fi
+
+if [ ! -w "$GF_PATHS_DATA" ]; then
+    echo "GF_PATHS_DATA='$GF_PATHS_DATA' is not writable."
+    PERMISSIONS_OK=1
+fi
+
+if [ ! -r "$GF_PATHS_HOME" ]; then
+    echo "GF_PATHS_HOME='$GF_PATHS_HOME' is not readable."
+    PERMISSIONS_OK=1
+fi
+
+if [ $PERMISSIONS_OK -eq 1 ]; then
+    echo "You may have issues with file permissions, more information here: http://docs.grafana.org/installation/docker/#migration-from-a-previous-version-of-the-docker-container-to-5-1-or-later"
+fi
+
+if [ ! -d "$GF_PATHS_PLUGINS" ]; then
+    mkdir "$GF_PATHS_PLUGINS"
+fi
+
+if [ ! -z ${GF_AWS_PROFILES+x} ]; then
+    > "$GF_PATHS_HOME/.aws/credentials"
+
+    for profile in ${GF_AWS_PROFILES}; do
+        access_key_varname="GF_AWS_${profile}_ACCESS_KEY_ID"
+        secret_key_varname="GF_AWS_${profile}_SECRET_ACCESS_KEY"
+        region_varname="GF_AWS_${profile}_REGION"
+
+        if [ ! -z "${!access_key_varname}" -a ! -z "${!secret_key_varname}" ]; then
+            echo "[${profile}]" >> "$GF_PATHS_HOME/.aws/credentials"
+            echo "aws_access_key_id = ${!access_key_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
+            echo "aws_secret_access_key = ${!secret_key_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
+            if [ ! -z "${!region_varname}" ]; then
+                echo "region = ${!region_varname}" >> "$GF_PATHS_HOME/.aws/credentials"
+            fi
+        fi
+    done
+
+    chmod 600 "$GF_PATHS_HOME/.aws/credentials"
+fi
+
+# Convert all environment variables with names ending in __FILE into the content of
+# the file that they point at and use the name without the trailing __FILE.
+# This can be used to carry in Docker secrets.
+for VAR_NAME in $(env | grep '^GF_[^=]\+__FILE=.\+' | sed -r "s/([^=]*)__FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"__FILE
+    if [ "${!VAR_NAME}" ]; then
+        echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
+        exit 1
+    fi
+    echo "Getting secret $VAR_NAME from ${!VAR_NAME_FILE}"
+    export "$VAR_NAME"="$(< "${!VAR_NAME_FILE}")"
+    unset "$VAR_NAME_FILE"
+done
+
+export HOME="$GF_PATHS_HOME"
+
+if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
+  OLDIFS=$IFS
+  IFS=','
+  for plugin in ${GF_INSTALL_PLUGINS}; do
+    IFS=$OLDIFS
+    if [[ $plugin =~ .*\;.* ]]; then
+        pluginUrl=$(echo "$plugin" | cut -d';' -f 1)
+        pluginWithoutUrl=$(echo "$plugin" | cut -d';' -f 2)
+        grafana-cli --pluginUrl "${pluginUrl}" --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${pluginWithoutUrl}
+    else
+        grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
+    fi
+  done
+fi
+
+exec grafana-server                                         \
+  --homepath="$GF_PATHS_HOME"                               \
+  --config="$GF_PATHS_CONFIG"                               \
+  --packaging=docker                                        \
+  "$@"                                                      \
+  cfg:default.log.mode="console"                            \
+  cfg:default.paths.data="$GF_PATHS_DATA"                   \
+  cfg:default.paths.logs="$GF_PATHS_LOGS"                   \
+  cfg:default.paths.plugins="$GF_PATHS_PLUGINS"             \
+  cfg:default.paths.provisioning="$GF_PATHS_PROVISIONING"

--- a/images/grafana/run.sh
+++ b/images/grafana/run.sh
@@ -2,5 +2,4 @@
 
 set -m
 echo "Starting Grafana"
-cat /etc/grafana/provisioning-noenv/datasources/influxdb.yaml | envsubst > /etc/grafana/provisioning/datasources/influxdb.yaml && \
-exec /usr/share/grafana/bin/grafana-server --config=/etc/grafana/cfg/grafana.ini
+/usr/share/grafana/bin/grafana-server --config=/etc/grafana/cfg/grafana.ini

--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -58,8 +58,8 @@ spec:
       - name: grafana
         image: monitoring-grafana:latest
         env:
-	  - name: GF_PATHS_CONFIG
-	    value: /etc/grafana/cfg/grafana.ini
+          - name: GF_PATHS_CONFIG
+            value: /etc/grafana/cfg/grafana.ini
           - name: GF_SECURITY_ADMIN_USER
             valueFrom:
               secretKeyRef:

--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -58,6 +58,8 @@ spec:
       - name: grafana
         image: monitoring-grafana:latest
         env:
+	  - name: GF_PATHS_CONFIG
+	    value: /etc/grafana/cfg/grafana.ini
           - name: GF_SECURITY_ADMIN_USER
             valueFrom:
               secretKeyRef:
@@ -82,7 +84,7 @@ spec:
           - name: config
             mountPath: /etc/grafana/cfg
           - name: datasources
-            mountPath: /etc/grafana/provisioning-noenv/datasources
+            mountPath: /etc/grafana/provisioning/datasources
           - name: dashboards-cfg
             mountPath: /etc/grafana/provisioning/dashboards
       - name: watcher
@@ -143,7 +145,8 @@ data:
         access: proxy
         url: "http://influxdb.monitoring.svc:8086"
         user: "$INFLUXDB_USERNAME"
-        password: "$INFLUXDB_PASSWORD"
+        secureJsonData:
+          password: "$INFLUXDB_PASSWORD"
         database: "k8s"
         isDefault: true
         version: 1

--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -21,6 +21,8 @@ data:
     [users]
     # Default UI theme ("dark" or "light")
     default_theme = dark
+    [security]
+    allow_embedding = true
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
Fixes https://github.com/gravitational/gravity/issues/1703 in 5.5.x.
## Implementation
* Synchronized grafana dockerfile and run.sh with upstream.
* Updated UID for default dashboard to `default`, because URL `dashboard/db/cluster` is deprecated(see gravity [changes](https://github.com/gravitational/gravity/pull/1730/files#diff-f0cd04305a9ab5a61a359a9c56132b82L174)) and returns weird uid instead of using uid from dashboard definition.
* In this release grafana supports the substitution of ENV variables in provisioned resources, so no more `envsubst` in entrypoint. Changed yaml files accordingly.