### PR TITLE
Fix a few watcher issues with rollups

### DIFF
--- a/watcher/lib/influxdb/influxdb.go
+++ b/watcher/lib/influxdb/influxdb.go
@@ -169,6 +169,12 @@ func (c *Client) CreateRollup(r Rollup) error {
 	log.WithField("query", query).Info("New rollup.")
 
 	if err = c.execQuery(query); err != nil {
+		if trace.IsAlreadyExists(ConvertError(err)) {
+			log.Info("Continuous already exists with different parameters. Updating it.")
+			if err = c.UpdateRollup(r); err != nil {
+				return trace.Wrap(err)
+			}
+		}
 		return trace.Wrap(err)
 	}
 	return nil

--- a/watcher/tool/watcher/dashboards.go
+++ b/watcher/tool/watcher/dashboards.go
@@ -62,6 +62,7 @@ func receiveAndCreateDashboards(ctx context.Context, client *grafana.Client,
 			case watch.Added, watch.Modified:
 				log := log.WithField("configmap", update.ResourceUpdate.Meta())
 				for _, dashboard := range update.Data {
+					dashboard := dashboard
 					handler := func() error {
 						return client.CreateDashboard(dashboard)
 					}

--- a/watcher/tool/watcher/dashboards.go
+++ b/watcher/tool/watcher/dashboards.go
@@ -81,6 +81,7 @@ func receiveAndCreateDashboards(ctx context.Context, client *grafana.Client,
 			case watch.Deleted:
 				log := log.WithField("configmap", update.ResourceUpdate.Meta())
 				for _, dashboard := range update.Data {
+					dashboard := dashboard
 					handler := func() error {
 						return client.DeleteDashboard(dashboard)
 					}

--- a/watcher/tool/watcher/main.go
+++ b/watcher/tool/watcher/main.go
@@ -115,14 +115,20 @@ func runRetryLoop(ctx context.Context) chan<- func() error {
 			case handler := <-retryC:
 				handlers = append(handlers, handler)
 			case <-timer.C:
-				for i, handler := range handlers {
+				var i int
+				numHandlers := len(handlers)
+				for i < numHandlers {
+					handler := handlers[i]
 					if err := handler(); err != nil {
 						log.WithError(err).Warn("Failed to complete handler.")
+						i++
 						continue
 					}
 					// Remove handler
 					handlers = append(handlers[:i], handlers[i+1:]...)
+					numHandlers--
 				}
+				handlers = handlers[:i]
 			case <-ctx.Done():
 				return
 			}

--- a/watcher/tool/watcher/rollups.go
+++ b/watcher/tool/watcher/rollups.go
@@ -79,6 +79,7 @@ func receiveAndManageRollups(ctx context.Context, client *influxdb.Client, ch <-
 						continue
 					}
 
+					rollup := rollup
 					switch update.EventType {
 					case watch.Added:
 						handler := func() error {


### PR DESCRIPTION
* Fix issue with out of bound error.
* Recreate rollup if it exist with the same name but different parameters.