### PR TITLE
Scale up replicas based on nodes count

### DIFF
--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -83,6 +83,15 @@ if [ $1 = "update" ]; then
 
     echo "---> Freezing"
     rig freeze
+
+    if [ $(kubectl get nodes -lgravitational.io/k8s-role=master --output=go-template --template="{{len .items}}") -gt 1 ]
+    then
+	kubectl --namespace monitoring patch prometheuses.monitoring.coreos.com k8s --type=json -p='[{"op": "replace", "path": "/spec/replicas", "value": 2}]'
+	kubectl --namespace monitoring patch alertmanagers.monitoring.coreos.com main --type=json -p='[{"op": "replace", "path": "/spec/replicas", "value": 2}]'
+    fi
+    # check for readiness of prometheus pod
+    kubectl --namespace monitoring wait --for=condition=ready pod prometheus-k8s-0
+    
 elif [ $1 = "rollback" ]; then
     echo "---> Reverting changeset $RIG_CHANGESET"
     rig revert

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -4,8 +4,11 @@
 
 for file in /var/lib/gravity/resources/crds/*
 do
-    head -n -6 $file | /opt/bin/kubectl create -f -
+    /opt/bin/kubectl create -f -
 done
+
+# Wait until setup of CRDs are done
+until /opt/bin/kubectl get servicemonitors --all-namespaces ; do echo $(date) ": Waiting for CRDs to setup"; sleep 5; done
 
 # Generate password for Grafana administrator
 password=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | tr -d '\n ' | /opt/bin/base64)
@@ -18,3 +21,12 @@ done
 
 /opt/bin/kubectl create -f /var/lib/gravity/resources/prometheus/
 /opt/bin/kubectl create -f /var/lib/gravity/resources/nethealth/
+
+if [ $(/opt/bin/kubectl get nodes -lgravitational.io/k8s-role=master --output=go-template --template="{{len .items}}") -gt 1 ]
+then
+    /opt/bin/kubectl --namespace monitoring patch prometheuses.monitoring.coreos.com k8s --type=json -p='[{"op": "replace", "path": "/spec/replicas", "value": 2}]'
+    /opt/bin/kubectl --namespace monitoring patch alertmanagers.monitoring.coreos.com main --type=json -p='[{"op": "replace", "path": "/spec/replicas", "value": 2}]'
+fi
+
+# check for readiness of prometheus pod
+/opt/bin/kubectl --namespace monitoring wait --for=condition=ready pod prometheus-k8s-0

--- a/resources/prometheus/alertmanager-alertmanager.yaml
+++ b/resources/prometheus/alertmanager-alertmanager.yaml
@@ -9,7 +9,7 @@ spec:
   baseImage: leader.telekube.local:5000/prometheus/alertmanager
   nodeSelector:
     gravitational.io/k8s-role: master
-  replicas: 3
+  replicas: 1
   securityContext:
     fsGroup: 2000
     runAsNonRoot: true

--- a/resources/prometheus/prometheus-prometheus.yaml
+++ b/resources/prometheus/prometheus-prometheus.yaml
@@ -14,7 +14,7 @@ spec:
   baseImage: leader.telekube.local:5000/prometheus/prometheus
   nodeSelector:
     gravitational.io/k8s-role: master
-  replicas: 2
+  replicas: 1
   resources:
     requests:
       memory: 400Mi


### PR DESCRIPTION
----

### Description
Backport of changes from 7.0.x branch. There is no sense to have 2+ replicas
of Prometheus/Alertmanager on one-node clusters. Scale them up to 2 when we have 2+ nodes.

### ToDo
- [] Manual testing
- [] Address review comments