### PR TITLE
ensure gravitational services tolerate any taint

### DIFF
--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -52,13 +52,8 @@ spec:
         runAsUser: 65534
       serviceAccountName: monitoring
       tolerations:
-      - key: "gravitational.io/runlevel"
-        value: system
-        operator: Equal
-        # allows to run on master nodes
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       containers:
       - name: grafana
         image: monitoring-grafana:latest

--- a/resources/nethealth/nethealth.yaml
+++ b/resources/nethealth/nethealth.yaml
@@ -129,11 +129,8 @@ spec:
       terminationGracePeriodSeconds: 5
       serviceAccountName: nethealth
       tolerations:
-        # Tolerate all taints
-        - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
+      # tolerate any taints
+      - operator: "Exists"
       containers:
         - name: nethealth
           image: quay.io/gravitational/nethealth-dev:7.1.6

--- a/resources/prometheus/0prometheus-operator-deployment.yaml
+++ b/resources/prometheus/0prometheus-operator-deployment.yaml
@@ -37,6 +37,9 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
       priorityClassName: monitoring-high-priority
+      tolerations:
+      # tolerate any taints
+      - operator: "Exists"
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/resources/prometheus/alertmanager-alertmanager.yaml
+++ b/resources/prometheus/alertmanager-alertmanager.yaml
@@ -33,11 +33,6 @@ spec:
               app: alertmanager
               alertmanager: main
   tolerations:
-  - key: "gravitational.io/runlevel"
-    value: system
-    operator: Equal
-  # allows to run on master nodes
-  - key: "node-role.kubernetes.io/master"
-    operator: "Exists"
-    effect: "NoSchedule"
+  # tolerate any taint
+  - operator: "Exists"
   version: v0.16.2

--- a/resources/prometheus/kube-state-metrics-deployment.yaml
+++ b/resources/prometheus/kube-state-metrics-deployment.yaml
@@ -69,6 +69,9 @@ spec:
             memory: 150Mi
       nodeSelector:
         gravitational.io/k8s-role: master
+      tolerations:
+      # tolerate any taints
+      - operator: "Exists"
       priorityClassName: monitoring-high-priority
       securityContext:
         runAsNonRoot: true

--- a/resources/prometheus/node-exporter-daemonset.yaml
+++ b/resources/prometheus/node-exporter-daemonset.yaml
@@ -73,13 +73,8 @@ spec:
         runAsUser: 65534
       serviceAccountName: node-exporter
       tolerations:
-      - key: "gravitational.io/runlevel"
-        value: system
-        operator: Equal
-      # allows to run on master nodes
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      # tolerate any taint
+      - operator: "Exists"
       volumes:
       - hostPath:
           path: /proc

--- a/resources/prometheus/prometheus-adapter-deployment.yaml
+++ b/resources/prometheus/prometheus-adapter-deployment.yaml
@@ -43,6 +43,9 @@ spec:
           readOnly: false
       nodeSelector:
         gravitational.io/k8s-role: master
+      tolerations:
+      # tolerate any taints
+      - operator: "Exists"
       priorityClassName: monitoring-high-priority
       serviceAccountName: prometheus-adapter
       volumes:

--- a/resources/prometheus/prometheus-prometheus.yaml
+++ b/resources/prometheus/prometheus-prometheus.yaml
@@ -42,13 +42,8 @@ spec:
               app: prometheus
               prometheus: k8s
   tolerations:
-  - key: "gravitational.io/runlevel"
-    value: system
-    operator: Equal
-  # allows to run on master nodes
-  - key: "node-role.kubernetes.io/master"
-    operator: "Exists"
-    effect: "NoSchedule"
+  # tolerate any taints
+  - operator: "Exists"
   additionalScrapeConfigs:
     name: prometheus-additional-scrape-configs
     key: additional-scrape-configs.yaml

--- a/resources/watcher.yaml
+++ b/resources/watcher.yaml
@@ -23,12 +23,8 @@ spec:
       priorityClassName: monitoring-high-priority
       serviceAccountName: monitoring-updater
       tolerations:
-      - key: "gravitational.io/runlevel"
-        value: system
-        operator: Equal
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       containers:
         - name: watcher
           image: watcher:latest


### PR DESCRIPTION
Customers can set any taint with an application manifest, so gravitational components sort of need to support any taint in order to run. This isn't a great solution, since we probably want to follow the builtin kubernetes health related taints. For now, support any taint so that customer applied taints don't block the builtins from functioning. 