### PR TITLE
Bump nethealth 7.1.7

### DIFF
--- a/resources/nethealth/nethealth.yaml
+++ b/resources/nethealth/nethealth.yaml
@@ -136,7 +136,7 @@ spec:
           operator: Exists
       containers:
         - name: nethealth
-          image: quay.io/gravitational/nethealth-dev:7.1.6
+          image: quay.io/gravitational/nethealth-dev:7.1.7
           command:
             - /nethealth
           args:


### PR DESCRIPTION
## Description
This PR bumps nethealth to version 7.1.7. This updated nethealth version exposes an additional latency summary metric. This new metric will be used by the updated latency check.

## Linked tickets and PRs
* Requires https://github.com/gravitational/satellite/pull/277