### PR TITLE
monitoring-app services tolerate any taint

### DIFF
--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -49,13 +49,8 @@ spec:
       serviceAccountName: monitoring
       priorityClassName: monitoring-high-priority
       tolerations:
-      - key: "gravitational.io/runlevel"
-        value: system
-        operator: Equal
-        # allows to run on master nodes
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       containers:
       - name: grafana
         image: monitoring-grafana:latest

--- a/resources/heapster.yaml
+++ b/resources/heapster.yaml
@@ -24,13 +24,8 @@ spec:
       serviceAccountName: monitoring
       priorityClassName: monitoring-high-priority
       tolerations:
-      - key: "gravitational.io/runlevel"
-        value: system
-        operator: Equal
-        # allows to run on master nodes
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       nodeSelector:
         gravitational.io/k8s-role: master
       securityContext:

--- a/resources/influxdb.yaml
+++ b/resources/influxdb.yaml
@@ -28,13 +28,8 @@ spec:
       securityContext:
         runAsUser: -1
       tolerations:
-      - key: "gravitational.io/runlevel"
-        value: system
-        operator: Equal
-        # allows to run on master nodes
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       containers:
       - name: watcher
         image: watcher:latest

--- a/resources/kapacitor.yaml
+++ b/resources/kapacitor.yaml
@@ -26,13 +26,8 @@ spec:
       securityContext:
         runAsUser: -1
       tolerations:
-      - key: "gravitational.io/runlevel"
-        value: system
-        operator: Equal
-        # allows to run on master nodes
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       containers:
         - name: watcher
           image: watcher:latest

--- a/resources/nethealth/nethealth.yaml
+++ b/resources/nethealth/nethealth.yaml
@@ -123,11 +123,8 @@ spec:
       serviceAccountName: nethealth
       priorityClassName: monitoring-high-priority
       tolerations:
-        # Tolerate all taints
-        - effect: NoSchedule
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
+      # tolerate any taints
+      - operator: "Exists"
       containers:
         - name: nethealth
           image: quay.io/gravitational/nethealth-dev:7.1.0

--- a/resources/telegraf.yaml
+++ b/resources/telegraf.yaml
@@ -24,13 +24,8 @@ spec:
       serviceAccountName: monitoring
       priorityClassName: monitoring-high-priority
       tolerations:
-      - key: "gravitational.io/runlevel"
-        value: system
-        operator: Equal
-        # allows to run on master nodes
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       securityContext:
         runAsUser: -1
       containers:
@@ -77,10 +72,8 @@ spec:
       serviceAccountName: monitoring
       priorityClassName: monitoring-high-priority
       tolerations:
-        # allows to run on master nodes
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      # tolerate any taints
+      - operator: "Exists"
       securityContext:
         runAsUser: -1
       containers:
@@ -157,6 +150,9 @@ spec:
         gravitational.io/k8s-role: node
       serviceAccountName: monitoring
       priorityClassName: monitoring-high-priority
+      tolerations:
+      # tolerate any taints
+      - operator: "Exists"
       securityContext:
         runAsUser: -1
       containers:


### PR DESCRIPTION
To support customers placing taints on their nodes, gravity services need to tolerate any taint.

Port #190 for InfluxDB monitoring stack.

Tracking: https://github.com/gravitational/gravity/issues/2281