### PR TITLE
Build watcher binary as non-root, upgrade go

### DIFF
--- a/watcher/Makefile
+++ b/watcher/Makefile
@@ -1,4 +1,4 @@
-BUILDBOX := quay.io/gravitational/debian-venti:go1.11.5-stretch
+BUILDBOX := quay.io/gravitational/debian-venti:go1.15.3-buster
 BUILDDIR := $(abspath build)
 CURDIR := $(dir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST)))
 DSTDIR := /gopath/src/github.com/gravitational/monitoring-app/watcher

--- a/watcher/Makefile
+++ b/watcher/Makefile
@@ -36,7 +36,9 @@ container: build
 build:
 	mkdir -p $(BUILDDIR)
 	docker run -i --rm=true \
+		-u $$(id -u):$$(id -g) \
 		-v $(CURDIR):$(DSTDIR) \
+		-e GOCACHE=/tmp/.cache \
 		$(BUILDBOX) \
 		/bin/bash -c "make -C $(DSTDIR) build-inside-container"
 


### PR DESCRIPTION
## Summary
This pr:

1) fixes ownership of the built `watcher` binary
2) opportunistically upgrades the go version

## Testing Done
```
walt@work:~/git/monitoring-app$ make -C watcher                                                                    
make: Entering directory '/home/walt/git/monitoring-app/watcher'
mkdir -p /home/walt/git/monitoring-app/watcher/build
docker run -i --rm=true \
        -u $(id -u):$(id -g) \
        -v /home/walt/git/monitoring-app/watcher/:/gopath/src/github.com/gravitational/monitoring-app/watcher \
        -e GOCACHE=/tmp/.cache \
        quay.io/gravitational/debian-venti:go1.15.3-buster \
        /bin/bash -c "make -C /gopath/src/github.com/gravitational/monitoring-app/watcher build-inside-container"
make: Entering directory '/gopath/src/github.com/gravitational/monitoring-app/watcher'
GOOS=linux GOARCH=amd64 go build -ldflags "-w" -o /gopath/src/github.com/gravitational/monitoring-app/watcher/build/watcher github.com/gravitational/monitoring-app/watcher/tool/watcher
make: Leaving directory '/gopath/src/github.com/gravitational/monitoring-app/watcher'
docker build -t watcher:0.0.3 .
Sending build context to Docker daemon  56.75MB
Step 1/5 : FROM quay.io/gravitational/debian-tall:stretch
 ---> e79ebe662aad
Step 2/5 : RUN test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> 2b884441f839
Step 3/5 : ADD Dockerfile /
 ---> Using cache
 ---> e23e7c71373e
Step 4/5 : ADD build/watcher /
 ---> Using cache
 ---> 6851d2af0b13
Step 5/5 : ENTRYPOINT ["/usr/bin/dumb-init", "/watcher"]
 ---> Using cache
 ---> dc6323ddfe75
Successfully built dc6323ddfe75
Successfully tagged watcher:0.0.3
make: Leaving directory '/home/walt/git/monitoring-app/watcher'
walt@work:~/git/monitoring-app$ ls -l watcher/build/watcher 
-rwxr-xr-x 1 walt walt 30421773 Nov  3 18:30 watcher/build/watcher
```

## Notes
While performing some routine maintenance on jenkins, I noticed that this binary was being created with `root:root` ownership -- causing trouble when it came time to delete it.

```
[jenkins@jenkins workspace]$ find Gravity-PR* \! -user jenkins -print | xargs ls -l
-rwxr-xr-x. 1 root root 33043946 Oct 27 11:45 Gravity-PR-5.2_PR-2276-XHATQITQT6ZRUI4MHPBUKLXDUDZ4LR7H34O7HGKKJK5RJT2E6NWQ/e/build/monitoring-app/watcher/build/watcher
-rwxr-xr-x. 1 root root 33043946 Oct 28 23:37 Gravity-PR-5.2_PR-2291-TXWE6EWON2OWQ4IX7FRWCYS47VNEEWGOT5VE6MOSV4RM7NPV2FNA/e/build/monitoring-app/watcher/build/watcher
-rwxr-xr-x. 1 root root 33043946 Nov  3 19:04 Gravity-PR-5.2_PR-2297-Q6YK7OKSWT7653ED5WRDBZHG22MJRRW26ZVHSYEWE4KJYNSGLDOQ/e/build/monitoring-app/watcher/build/watcher
-rwxr-xr-x. 1 root root 33043946 Nov  2 18:29 Gravity-PR-5.2_PR-2301-YILO2SC456MHRSKMRCKY2TVPEEI7LWZHEMZ2WT5LDVTFFDHW3BNQ/e/build/monitoring-app/watcher/build/watcher
```

Meta note: we may consider podman or some sort of rootless dind for our build system to categorically remove issues like this.  This is [not the first time](https://github.com/gravitational/gravity/issues/2103) we've had trouble with this.

The image upgrade was needed because `debian-venti:go1.11.5-stretch` has a broken `/tmp` as discussed in https://github.com/gravitational/docker-debian/pull/39 -- if `1.15.3` is too risky, I could rebuild 1.11.5 with the fix discussed there.