### PR TITLE
Kubernetes 1.19 support

### DIFF
--- a/images/hook/Dockerfile
+++ b/images/hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/rig:7.0.2
+FROM quay.io/gravitational/rig:7.1.2
 
 # Ensure nsswitch is set so localhost will be resolved locally
 # https://github.com/gravitational/gravity/issues/1046

--- a/resources/grafana.yaml
+++ b/resources/grafana.yaml
@@ -24,7 +24,7 @@ data:
     [security]
     allow_embedding = true
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/resources/nethealth/nethealth.yaml
+++ b/resources/nethealth/nethealth.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:

--- a/resources/prometheus/0prometheus-operator-deployment.yaml
+++ b/resources/prometheus/0prometheus-operator-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/resources/prometheus/kube-state-metrics-deployment.yaml
+++ b/resources/prometheus/kube-state-metrics-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/resources/prometheus/node-exporter-daemonset.yaml
+++ b/resources/prometheus/node-exporter-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/resources/prometheus/prometheus-adapter-deployment.yaml
+++ b/resources/prometheus/prometheus-adapter-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-adapter


### PR DESCRIPTION
## Description
This PR adds support for Kubernetes 1.19.
- Bump `rig` to `7.1.2`.
- `apps/v1beta2/{Deployment,DaemonSet}` is deprecated. Use `apps/v1/{Deployment,DaemonSet}` instead.
- `extensions/v1beta1/PodSecurityPolicy` is deprecated. Use `policy/v1beta1/PodSecurityPolicy` instead.