### PR TITLE
[7.0.x] Update node exporter collector configuration

### DIFF
--- a/images/hook/entrypoint.sh
+++ b/images/hook/entrypoint.sh
@@ -91,6 +91,7 @@ if [ $1 = "update" ]; then
 	kubectl --namespace monitoring patch alertmanagers.monitoring.coreos.com main --type=json -p='[{"op": "replace", "path": "/spec/replicas", "value": 2}]'
     fi
     # check for readiness of prometheus pod
+    timeout 5m sh -c "while ! kubectl get pod prometheus-k8s-0; do sleep 10; done"
     kubectl --namespace monitoring wait --for=condition=ready pod prometheus-k8s-0
 
 

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -31,4 +31,5 @@ then
 fi
 
 # check for readiness of prometheus pod
+timeout 5m sh -c "while ! /opt/bin/kubectl get pod prometheus-k8s-0; do sleep 10; done"
 /opt/bin/kubectl --namespace monitoring wait --for=condition=ready pod prometheus-k8s-0

--- a/resources/prometheus/node-exporter-daemonset.yaml
+++ b/resources/prometheus/node-exporter-daemonset.yaml
@@ -2,17 +2,19 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: node-exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/version: v0.18.1
   name: node-exporter
   namespace: monitoring
 spec:
   selector:
     matchLabels:
-      app: node-exporter
+      app.kubernetes.io/name: node-exporter
   template:
     metadata:
       labels:
-        app: node-exporter
+        app.kubernetes.io/name: node-exporter
+        app.kubernetes.io/version: v0.18.1
     spec:
       containers:
       - args:
@@ -22,8 +24,7 @@ spec:
         - --path.rootfs=/host/root
         - --no-collector.wifi
         - --no-collector.hwmon
-        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
-        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         image: quay.io/prometheus/node-exporter:v0.18.1
         name: node-exporter
         resources:
@@ -47,7 +48,7 @@ spec:
       - args:
         - --logtostderr
         - --secure-listen-address=[$(IP)]:9100
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://127.0.0.1:9100/
         env:
         - name: IP
@@ -77,8 +78,7 @@ spec:
         runAsUser: 65534
       serviceAccountName: node-exporter
       tolerations:
-      # tolerate any taint
-      - operator: "Exists"
+      - operator: Exists
       volumes:
       - hostPath:
           path: /proc
@@ -89,3 +89,6 @@ spec:
       - hostPath:
           path: /
         name: root
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%

--- a/resources/prometheus/node-exporter-service.yaml
+++ b/resources/prometheus/node-exporter-service.yaml
@@ -12,4 +12,5 @@ spec:
     port: 9100
     targetPort: https
   selector:
-    app: node-exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/version: v0.18.1


### PR DESCRIPTION
Fixes gathering mount points errors in logs in node-exporter container:

``` shell
time="2021-03-29T20:07:41Z" level=error msg="error gathering metrics: 14 error(s) occurred:\n* [from Gatherer #2] collected metric \"node_filesystem_device
_error\" { label:<name:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run\" > gauge:<value:0 > }
 was collected before with the same name and label values\n* [from Gatherer #2] collected metric \"node_filesystem_size_bytes\" { label:<name:\"device\" va
lue:\"tmpfs\" > label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run\" > gauge:<value:3.124826112e+09 > } was collected before
with the same name and label values\n* [from Gatherer #2] collected metric \"node_filesystem_free_bytes\" { label:<name:\"device\" value:\"tmpfs\" > label:
<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run\" > gauge:<value:3.12281088e+09 > } was collected before with the same name and
label values\n* [from Gatherer #2] collected metric \"node_filesystem_avail_bytes\" { label:<name:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value
:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run\" > gauge:<value:3.12281088e+09 > } was collected before with the same name and label values\n* [from
Gatherer #2] collected metric \"node_filesystem_files\" { label:<name:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"m
ountpoint\" value:\"/run\" > gauge:<value:762897 > } was collected before with the same name and label values\n* [from Gatherer #2] collected metric \"node
_filesystem_files_free\" { label:<name:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run\" > ga
uge:<value:762415 > } was collected before with the same name and label values\n* [from Gatherer #2] collected metric \"node_filesystem_readonly\" { label:
<name:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run\" > gauge:<value:0 > } was collected be
fore with the same name and label values\n* [from Gatherer #2] collected metric \"node_filesystem_device_error\" { label:<name:\"device\" value:\"tmpfs\" >
 label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run/lock\" > gauge:<value:0 > } was collected before with the same name and l
abel values\n* [from Gatherer #2] collected metric \"node_filesystem_size_bytes\" { label:<name:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value:\
"tmpfs\" > label:<name:\"mountpoint\" value:\"/run/lock\" > gauge:<value:5.24288e+06 > } was collected before with the same name and label values\n* [from
Gatherer #2] collected metric \"node_filesystem_free_bytes\" { label:<name:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value:\"tmpfs\" > label:<nam
e:\"mountpoint\" value:\"/run/lock\" > gauge:<value:5.24288e+06 > } was collected before with the same name and label values\n* [from Gatherer #2] collecte
d metric \"node_filesystem_avail_bytes\" { label:<name:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" val
ue:\"/run/lock\" > gauge:<value:5.24288e+06 > } was collected before with the same name and label values\n* [from Gatherer #2] collected metric \"node_file
system_files\" { label:<name:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run/lock\" > gauge:<
value:762897 > } was collected before with the same name and label values\n* [from Gatherer #2] collected metric \"node_filesystem_files_free\" { label:<na
me:\"device\" value:\"tmpfs\" > label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run/lock\" > gauge:<value:762895 > } was colle
cted before with the same name and label values\n* [from Gatherer #2] collected metric \"node_filesystem_readonly\" { label:<name:\"device\" value:\"tmpfs\
" > label:<name:\"fstype\" value:\"tmpfs\" > label:<name:\"mountpoint\" value:\"/run/lock\" > gauge:<value:0 > } was collected before with the same name an
d label values\n" source="log.go:172"
```

New pod resource was taken from [kube-prometheus v0.6.0](https://github.com/prometheus-operator/kube-prometheus/blob/release-0.6/manifests/node-exporter-daemonset.yaml).