### PR TITLE
[5.5] Run build under current user

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,15 @@
+FROM quay.io/gravitational/debian-venti:go1.9-stretch
+
+ARG UID
+ARG GID
+
+RUN getent group  $GID || groupadd builder --gid=$GID -o && \
+    getent passwd $UID || useradd builder --uid=$UID --gid=$GID --create-home --shell=/bin/sh;
+
+RUN mkdir -p /.cache && chown -R $UID:$GID /.cache && chown -R $UID:$GID /gopath
+
+USER $UID:$GID
+
+RUN go get github.com/tools/godep
+
+ENV PATH="$PATH:/gopath/bin"

--- a/images/heapster/Makefile
+++ b/images/heapster/Makefile
@@ -5,20 +5,16 @@ REPODIR:=$(GOPATH)/src/k8s.io/heapster
 PREFIX=gravity
 GOFLAGS=-a -installsuffix cgo --ldflags '-w'
 OUT=/targetdir/heapster
-BUILD_UID?=1000
 
 all: $(OUT)
 
 $(OUT):
-	useradd --uid $$BUILD_UID builder
-	chown -R builder $(GOPATH)
 	@echo "\n---> Building $@\n"
-	sudo -E -u builder HOME=~builder PATH="$$PATH" bash -c "go get github.com/tools/godep"
-	sudo -E -u builder HOME=~builder PATH="$$PATH" bash -c "mkdir -p $(GOPATH)/src/k8s.io"
-	sudo -E -u builder HOME=~builder PATH="$$PATH" bash -c "cd $(GOPATH)/src/k8s.io && git clone https://github.com/kubernetes/heapster -b $(VER)"
-	sudo -E -u builder HOME=~builder PATH="$$PATH:$(GOPATH)/bin" bash -c "cd $(REPODIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build $(GOFLAGS) ./..."
-	sudo -E -u builder HOME=~builder PATH="$$PATH:$(GOPATH)/bin" bash -c "cd $(REPODIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o heapster $(GOFLAGS) k8s.io/heapster/metrics && mv $(REPODIR)/heapster /targetdir/"
-	sudo -E -u builder HOME=~builder PATH="$$PATH:$(GOPATH)/bin" bash -c "cd $(REPODIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o eventer $(GOFLAGS) k8s.io/heapster/events && mv $(REPODIR)/eventer /targetdir/"
+	mkdir -p $(GOPATH)/src/k8s.io
+	cd $(GOPATH)/src/k8s.io && git clone https://github.com/kubernetes/heapster -b $(VER)
+	cd $(REPODIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build $(GOFLAGS) ./...
+	cd $(REPODIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o heapster $(GOFLAGS) k8s.io/heapster/metrics && mv $(REPODIR)/heapster /targetdir/
+	cd $(REPODIR) && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o eventer $(GOFLAGS) k8s.io/heapster/events && mv $(REPODIR)/eventer /targetdir/
 
 clean:
 	rm -f build/heapster

--- a/watcher/Makefile
+++ b/watcher/Makefile
@@ -37,7 +37,9 @@ container: build
 build:
 	mkdir -p $(BUILDDIR)
 	docker run -i --rm=true \
+		--user $$(id -u):$$(id -g) \
 		-v $(CURDIR):$(DSTDIR) \
+		-e GOCACHE=/tmp/gocache \
 		-e VERSION=$(VERSION) \
 		-e COMMIT=$(COMMIT) \
 		$(BUILDBOX) \


### PR DESCRIPTION
Without this, the build creates some artifacts as root, while failing
when run as root for other artifacts.  Most notably this showed up
as part of the Drone CI build, which runs as root:

  useradd --uid $BUILD_UID builder
  useradd: UID 0 is not unique

As seen at https://drone.teleport.dev/gravitational/gravity/183/1/6

Backports 7bfff6f38d320ad02ce47292f8e2ad96eac881c1 / #201 

## Testing Done
<details><summary>as non-root</summary>

```console
walt@work:~/git/monitoring-app$ make clean
make -C watcher clean
make[1]: Entering directory '/home/walt/git/monitoring-app/watcher'
rm -rf /home/walt/git/monitoring-app/watcher/build
make[1]: Leaving directory '/home/walt/git/monitoring-app/watcher'
make -C images clean
make[1]: Entering directory '/home/walt/git/monitoring-app/images'
make -C /home/walt/git/monitoring-app/images/heapster -f Makefile clean
make[2]: Entering directory '/home/walt/git/monitoring-app/images/heapster'
rm -f build/heapster
rm -f build/eventer
make[2]: Leaving directory '/home/walt/git/monitoring-app/images/heapster'
make -C /home/walt/git/monitoring-app/images/influxdb clean
make[2]: Entering directory '/home/walt/git/monitoring-app/images/influxdb'
rm -rf build/influx*
make[2]: Leaving directory '/home/walt/git/monitoring-app/images/influxdb'
make[1]: Leaving directory '/home/walt/git/monitoring-app/images'
walt@work:~/git/monitoring-app$ make package
make -C watcher
make[1]: Entering directory '/home/walt/git/monitoring-app/watcher'
mkdir -p /home/walt/git/monitoring-app/watcher/build
docker run -i --rm=true \
        --user $(id -u):$(id -g) \
        -v /home/walt/git/monitoring-app/watcher/:/gopath/src/github.com/gravitational/monitoring-app/watcher \
        -e GOCACHE=/tmp/gocache \
        -e VERSION=5.5.25-1-g9d5767b0 \
        -e COMMIT=9d5767b0b63e25c90515df1784a989a5a9960684 \
        quay.io/gravitational/debian-venti:go1.12.17-stretch \
        /bin/bash -c "make -C /gopath/src/github.com/gravitational/monitoring-app/watcher build-inside-container"
make: Entering directory '/gopath/src/github.com/gravitational/monitoring-app/watcher'
GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/gravitational/monitoring-app/watcher/vendor/github.com/gravitational/version.gitCommit=9d5767b0b63e25c90515df1784a989a5a9960684 -X github.com/gravitational/monitoring-app/watcher/vendor/github.com/gravitational/version.version=5.5.25-1-g9d5767b0 -w" -o /gopath/src/github.com/gravitational/monitoring-app/watcher/build/watcher github.com/gravitational/monitoring-app/watcher/tool/watcher
make: Leaving directory '/gopath/src/github.com/gravitational/monitoring-app/watcher'
docker build -t watcher:5.5.25-1-g9d5767b0 .
Sending build context to Docker daemon   71.3MB
Step 1/5 : FROM quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 2/5 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> 1a6c02c08dff
Step 3/5 : ADD Dockerfile /
 ---> Using cache
 ---> d2cb8f0ce4d0
Step 4/5 : ADD build/watcher /
 ---> 06934cc6f961
Step 5/5 : ENTRYPOINT ["/usr/bin/dumb-init", "/watcher"]
 ---> Running in 95c776348a30
Removing intermediate container 95c776348a30
 ---> 7b32cf51f8d0
Successfully built 7b32cf51f8d0
Successfully tagged watcher:5.5.25-1-g9d5767b0
make[1]: Leaving directory '/home/walt/git/monitoring-app/watcher'
make -C images all
make[1]: Entering directory '/home/walt/git/monitoring-app/images'
make -C /home/walt/git/monitoring-app/images/heapster -e VER=v1.5.4 TARGET=heapster TARGETDIR=heapster -f /home/walt/git/monitoring-app/images/buildbox.mk
make[2]: Entering directory '/home/walt/git/monitoring-app/images/heapster'

---> BuildBox for heapster:

docker run --rm=true \
        --user $(id -u):$(id -g) \
        --volume=/home/walt/git/monitoring-app/images/heapster:/assets \
        --volume=/home/walt/git/monitoring-app/images/heapster/build:/targetdir \
        --env="TARGETDIR=/targetdir" \
        --env="VER=v1.5.4" \
        $(cat /home/walt/git/monitoring-app/images/heapster/build/.bbox.iid) \
        make -f /assets/Makefile

---> Building /targetdir/heapster

mkdir -p /gopath/src/k8s.io
cd /gopath/src/k8s.io && git clone https://github.com/kubernetes/heapster -b v1.5.4
Cloning into 'heapster'...
Note: checking out '105c0f2e84ae9dc6de5a0ce8e9dd7d15e9abf014'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

cd /gopath/src/k8s.io/heapster && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo --ldflags '-w' ./...
cd /gopath/src/k8s.io/heapster && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o heapster -a -installsuffix cgo --ldflags '-w' k8s.io/heapster/metrics && mv /gopath/src/k8s.io/heapster/heapster /targetdir/
cd /gopath/src/k8s.io/heapster && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o eventer -a -installsuffix cgo --ldflags '-w' k8s.io/heapster/events && mv /gopath/src/k8s.io/heapster/eventer /targetdir/
make[2]: Leaving directory '/home/walt/git/monitoring-app/images/heapster'
make -e BUILDIMAGE=monitoring-heapster:5.5.25-1-g9d5767b0 TARGETDIR=heapster make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull  -t monitoring-heapster:5.5.25-1-g9d5767b0 heapster
Sending build context to Docker daemon  75.39MB
Step 1/6 : FROM quay.io/gravitational/debian-tall:stretch
stretch: Pulling from gravitational/debian-tall
Digest: sha256:efc3b0ca6d21c7856509245fb126ddb7041e7cebeddf1312dc3908e59d600d65
Status: Image is up to date for quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 2/6 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> 1a6c02c08dff
Step 3/6 : VOLUME /var/run/heapster/hosts
 ---> Using cache
 ---> 93911dc8bec9
Step 4/6 : ADD Dockerfile /
 ---> Using cache
 ---> c206cecb405c
Step 5/6 : ADD build/heapster /heapster
 ---> Using cache
 ---> 5d6c959414e2
Step 6/6 : ENTRYPOINT ["/heapster"]
 ---> Using cache
 ---> 0745af15bdac
Successfully built 0745af15bdac
Successfully tagged monitoring-heapster:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make -C /home/walt/git/monitoring-app/images/influxdb -e VER=v1.5.2 TARGET=influxd TARGETDIR=influxdb -f /home/walt/git/monitoring-app/images/buildbox.mk
make[2]: Entering directory '/home/walt/git/monitoring-app/images/influxdb'

---> BuildBox for influxd:

docker run --rm=true \
        --user $(id -u):$(id -g) \
        --volume=/home/walt/git/monitoring-app/images/influxdb:/assets \
        --volume=/home/walt/git/monitoring-app/images/influxdb/build:/targetdir \
        --env="TARGETDIR=/targetdir" \
        --env="VER=v1.5.2" \
        $(cat /home/walt/git/monitoring-app/images/influxdb/build/.bbox.iid) \
        make -f /assets/Makefile

---> Building /targetdir/influxd

mkdir -p /gopath/src/github.com/influxdata
cd /gopath/src/github.com/influxdata && git clone https://github.com/influxdata/influxdb -b v1.5.2
Cloning into 'influxdb'...
Note: checking out '02d7d4f043b34ecb4e9b2dbec298c6f9450c2a32'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

cd /gopath/src/github.com/influxdata/influxdb && python build.py --release --platform=linux --arch=static_amd64 --branch=v1.5.2
[INFO] print_banner:
  ___       __ _          ___  ___
 |_ _|_ _  / _| |_  ___ _|   \| _ )
  | || ' \|  _| | || \ \ / |) | _ \
 |___|_||_|_| |_|\_,_/_\_\___/|___/
  Build Script

[INFO] check_environ: Checking environment...
[INFO] check_prereqs: Checking for dependencies...
[INFO] main: Moving to git branch: v1.5.2
[INFO] go_get: Downloading `gdm`...
[INFO] go_get: Retrieving dependencies with `gdm`...
[INFO] build: Starting build for linux/static_amd64...
[INFO] build: Using Go version: 1.9
[INFO] build: Using git branch: HEAD
[INFO] build: Using git commit: 02d7d4f043b34ecb4e9b2dbec298c6f9450c2a32
[INFO] build: Sending build output to: /gopath/src/github.com/influxdata/influxdb/build
[INFO] build: Using version '1.5.2' for build.
[INFO] build: Building target: influx_stress
[INFO] build: Time taken: 5.46958s
[INFO] build: Building target: influxd
[INFO] build: Time taken: 12.212081s
[INFO] build: Building target: influx_inspect
[INFO] build: Time taken: 10.204809s
[INFO] build: Building target: influx
[INFO] build: Time taken: 5.533274s
[INFO] build: Building target: influx_tsm
[INFO] build: Time taken: 11.737196s
mv /gopath/src/github.com/influxdata/influxdb/build/influxd /gopath/src/github.com/influxdata/influxdb/build/influx /targetdir/
make[2]: Leaving directory '/home/walt/git/monitoring-app/images/influxdb'
make -e BUILDIMAGE=monitoring-influxdb:5.5.25-1-g9d5767b0 TARGETDIR=influxdb make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull  -t monitoring-influxdb:5.5.25-1-g9d5767b0 influxdb
Sending build context to Docker daemon  21.12MB
Step 1/9 : FROM quay.io/gravitational/debian-tall:stretch
stretch: Pulling from gravitational/debian-tall
Digest: sha256:efc3b0ca6d21c7856509245fb126ddb7041e7cebeddf1312dc3908e59d600d65
Status: Image is up to date for quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 2/9 : ENV INFLUXDB_HOME /influxdb
 ---> Using cache
 ---> 741a2021987e
Step 3/9 : ENV PATH $INFLUXDB_HOME:$PATH
 ---> Using cache
 ---> 32b84135b3ab
Step 4/9 : EXPOSE 8083 8086 8086/udp 8088 2003 4242 25826
 ---> Using cache
 ---> 31706f76a12e
Step 5/9 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> b91b28cd88fe
Step 6/9 : RUN set -ex && mkdir -p $INFLUXDB_HOME /data /logs
 ---> Using cache
 ---> e1f78fee4e13
Step 7/9 : ADD build/influx* $INFLUXDB_HOME/
 ---> Using cache
 ---> c88fe26a66c4
Step 8/9 : VOLUME ["/data"]
 ---> Using cache
 ---> 77e0b4b5fa0d
Step 9/9 : VOLUME ["/logs"]
 ---> Using cache
 ---> 1eb878b5794c
Successfully built 1eb878b5794c
Successfully tagged monitoring-influxdb:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make -e BUILDIMAGE=monitoring-grafana:5.5.25-1-g9d5767b0 EXTRA_ARGS="--build-arg GRAFANA_VERSION=6.7.4" TARGETDIR=grafana make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull --build-arg GRAFANA_VERSION=6.7.4 -t monitoring-grafana:5.5.25-1-g9d5767b0 grafana
Sending build context to Docker daemon  163.8kB
Step 1/20 : FROM debian:stretch-slim
stretch-slim: Pulling from library/debian
Digest: sha256:0ee501c41db93e0dc3b9b3851d3995db6ec8c66f71ef8a9fd0f52e5aa5abc2e1
Status: Image is up to date for debian:stretch-slim
 ---> eda1325acaaa
Step 2/20 : ARG GRAFANA_VERSION
 ---> Using cache
 ---> 033140b37c26
Step 3/20 : ARG GRAFANA_TGZ="https://dl.grafana.com/oss/release/grafana-${GRAFANA_VERSION}.linux-amd64.tar.gz"
 ---> Using cache
 ---> 3a273f409f60
Step 4/20 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> f3849a266aac
Step 5/20 : RUN set -ex && apt-get update && apt-get install -qq -y tar &&     apt-get autoremove -y &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 1ddefb6e31b5
Step 6/20 : ADD ${GRAFANA_TGZ} /tmp/grafana.tar.gz
Downloading [==================================================>]  65.08MB/65.08MB

 ---> Using cache
 ---> 6e7e405c67f2
Step 7/20 : RUN set -ex && mkdir /tmp/grafana && tar xfvz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 ---> Using cache
 ---> 5c2c2d0315cd
Step 8/20 : FROM debian:stretch-slim
stretch-slim: Pulling from library/debian
Digest: sha256:0ee501c41db93e0dc3b9b3851d3995db6ec8c66f71ef8a9fd0f52e5aa5abc2e1
Status: Image is up to date for debian:stretch-slim
 ---> eda1325acaaa
Step 9/20 : ARG GF_UID="472"
 ---> Using cache
 ---> 7c32f1b004dd
Step 10/20 : ARG GF_GID="472"
 ---> Using cache
 ---> 4109a57b1d8f
Step 11/20 : ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin     GF_PATHS_CONFIG="/etc/grafana/grafana.ini"     GF_PATHS_DATA="/var/lib/grafana"     GF_PATHS_HOME="/usr/share/grafana"     GF_PATHS_LOGS="/var/log/grafana"     GF_PATHS_PLUGINS="/var/lib/grafana/plugins"     GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 ---> Using cache
 ---> faa1bd335bf3
Step 12/20 : WORKDIR $GF_PATHS_HOME
 ---> Using cache
 ---> f0781131748d
Step 13/20 : RUN set -ex && apt-get update && apt-get install -qq -y libfontconfig ca-certificates dumb-init &&     apt-get autoremove -y &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 0263675a19fd
Step 14/20 : COPY --from=0 /tmp/grafana "$GF_PATHS_HOME"
 ---> Using cache
 ---> b0063cec1820
Step 15/20 : COPY rootfs/ /
 ---> Using cache
 ---> b4f42b66cc30
Step 16/20 : RUN set -ex && groupadd -r -g $GF_GID grafana &&     useradd -r -u $GF_UID -g grafana grafana &&     mkdir -p "$GF_PATHS_PROVISIONING/datasources"              "$GF_PATHS_PROVISIONING/dashboards"              "$GF_PATHS_PROVISIONING/notifiers"              "$GF_PATHS_LOGS"              "$GF_PATHS_PLUGINS"              "$GF_PATHS_DATA" &&     cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" &&     cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml &&     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" &&     chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 ---> Using cache
 ---> b68bc8cbce17
Step 17/20 : EXPOSE 3000
 ---> Using cache
 ---> 59963438a32a
Step 18/20 : COPY ./run.sh /run.sh
 ---> Using cache
 ---> 38d869a762d0
Step 19/20 : USER grafana
 ---> Using cache
 ---> 1c95eeac2398
Step 20/20 : ENTRYPOINT [  "/usr/bin/dumb-init", "/run.sh" ]
 ---> Using cache
 ---> d84336c0f8c3
Successfully built d84336c0f8c3
Successfully tagged monitoring-grafana:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make -e BUILDIMAGE=monitoring-kapacitor:5.5.25-1-g9d5767b0 EXTRA_ARGS="--build-arg KAPACITOR_VERSION=1.5.0" TARGETDIR=kapacitor make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull --build-arg KAPACITOR_VERSION=1.5.0 -t monitoring-kapacitor:5.5.25-1-g9d5767b0 kapacitor
Sending build context to Docker daemon  6.144kB
Step 1/13 : FROM quay.io/gravitational/debian-grande:stretch as downloader
stretch: Pulling from gravitational/debian-grande
Digest: sha256:ad2690fdced0d68b04ca59723e5e83cb430380f246c1d0605811bcfbfa36a9c9
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> cff1f7cdd5bf
Step 2/13 : ARG KAPACITOR_VERSION
 ---> Using cache
 ---> ecc8b26603ab
Step 3/13 : RUN set -ex && apt-get update &&     apt-get install -y curl tar &&     curl -sSL https://dl.influxdata.com/kapacitor/releases/kapacitor-${KAPACITOR_VERSION}_linux_amd64.tar.gz -o /kapacitor.tar.gz &&     tar xzf /kapacitor.tar.gz --strip-components=2
 ---> Using cache
 ---> f278b2e08d68
Step 4/13 : FROM quay.io/gravitational/debian-tall:stretch
stretch: Pulling from gravitational/debian-tall
Digest: sha256:efc3b0ca6d21c7856509245fb126ddb7041e7cebeddf1312dc3908e59d600d65
Status: Image is up to date for quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 5/13 : COPY --from=downloader /usr/bin/kapacitor /usr/bin/kapacitord /usr/bin/tickfmt /usr/bin/
 ---> Using cache
 ---> c1372692764c
Step 6/13 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> 633740961df3
Step 7/13 : EXPOSE 9092
 ---> Using cache
 ---> a201728b7b62
Step 8/13 : VOLUME /var/lib/kapacitor
 ---> Using cache
 ---> 61b63fa780ff
Step 9/13 : COPY kapacitor.conf /etc/kapacitor/kapacitor.conf
 ---> Using cache
 ---> 8adac577c89b
Step 10/13 : COPY entrypoint.sh /entrypoint.sh
 ---> Using cache
 ---> c617b44d569b
Step 11/13 : COPY loadalerts.sh /loadalerts.sh
 ---> Using cache
 ---> 7d3b02ac5c07
Step 12/13 : ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 ---> Using cache
 ---> 2f3f3916abaf
Step 13/13 : CMD ["/entrypoint.sh"]
 ---> Using cache
 ---> 8b375435daa3
Successfully built 8b375435daa3
Successfully tagged monitoring-kapacitor:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make -e BUILDIMAGE=monitoring-telegraf:5.5.25-1-g9d5767b0 EXTRA_ARGS="--build-arg TELEGRAF_VERSION=1.11.5" TARGETDIR=telegraf make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull --build-arg TELEGRAF_VERSION=1.11.5 -t monitoring-telegraf:5.5.25-1-g9d5767b0 telegraf
Sending build context to Docker daemon   21.5kB
Step 1/10 : FROM quay.io/gravitational/debian-grande:stretch AS downloader
stretch: Pulling from gravitational/debian-grande
Digest: sha256:ad2690fdced0d68b04ca59723e5e83cb430380f246c1d0605811bcfbfa36a9c9
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> cff1f7cdd5bf
Step 2/10 : ARG TELEGRAF_VERSION
 ---> Using cache
 ---> 8439393f4d39
Step 3/10 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> 58f61499029a
Step 4/10 : ENV DEBIAN_FRONTEND=noninteractive     TERM=xterm
 ---> Using cache
 ---> c5fa5ade5c10
Step 5/10 : RUN set -ex && apt-get update &&     apt-get install --yes --no-install-recommends curl tar &&     curl -sSL https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_amd64.tar.gz -o /telegraf.tar.gz &&     tar xzf /telegraf.tar.gz --strip-components=2
 ---> Using cache
 ---> 32ba40cf0f4e
Step 6/10 : FROM quay.io/gravitational/debian-tall:stretch
stretch: Pulling from gravitational/debian-tall
Digest: sha256:efc3b0ca6d21c7856509245fb126ddb7041e7cebeddf1312dc3908e59d600d65
Status: Image is up to date for quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 7/10 : COPY --from=downloader /usr/bin/telegraf /usr/bin/telegraf
 ---> Using cache
 ---> 2ffa723f8458
Step 8/10 : ADD rootfs/ /
 ---> Using cache
 ---> dc42f662f298
Step 9/10 : ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 ---> Using cache
 ---> f6982c2e6416
Step 10/10 : CMD ["/usr/bin/telegraf", "--config", "/etc/telegraf/telegraf.conf"]
 ---> Using cache
 ---> 5a2d72bad943
Successfully built 5a2d72bad943
Successfully tagged monitoring-telegraf:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
if [ -z "5525-1-g9d5767b0" ]; then \
  echo "CHANGESET is not set"; exit 1; \
fi;
make -e BUILDIMAGE=monitoring-hook:5.5.25-1-g9d5767b0 EXTRA_ARGS="--build-arg CHANGESET=monitoring-5525-1-g9d5767b0" TARGETDIR=hook make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull --build-arg CHANGESET=monitoring-5525-1-g9d5767b0 -t monitoring-hook:5.5.25-1-g9d5767b0 hook
Sending build context to Docker daemon  8.192kB
Step 1/7 : FROM quay.io/gravitational/rig:5.5.8
5.5.8: Pulling from gravitational/rig
Digest: sha256:a73b52308b045664e93ae9fe7e87e2a7d0f71a128914f2a2b1f8f225f4c6c618
Status: Image is up to date for quay.io/gravitational/rig:5.5.8
 ---> 3003333a77af
Step 2/7 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> ff1c7b4bc50c
Step 3/7 : ARG CHANGESET
 ---> Using cache
 ---> 6b14eba95d85
Step 4/7 : ENV RIG_CHANGESET $CHANGESET
 ---> Running in ef0821a4e356
Removing intermediate container ef0821a4e356
 ---> 2411cab71502
Step 5/7 : RUN set -ex && apt-get update &&     apt-get install --yes --no-install-recommends jq &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         ~/.bashrc         /usr/share/doc/         /usr/share/doc-base/         /usr/share/man/         /tmp/*
 ---> Running in bf87e1661675
+ apt-get update
Get:1 http://security.debian.org stretch/updates InRelease [53.0 kB]
Ign:2 http://httpredir.debian.org/debian stretch InRelease
Get:3 http://httpredir.debian.org/debian stretch-updates InRelease [93.6 kB]
Get:4 http://httpredir.debian.org/debian stretch Release [118 kB]
Get:5 http://security.debian.org stretch/updates/main amd64 Packages [696 kB]
Get:6 http://security.debian.org stretch/updates/main Translation-en [319 kB]
Get:7 http://security.debian.org stretch/updates/contrib amd64 Packages [1760 B]
Get:8 http://security.debian.org stretch/updates/contrib Translation-en [1759 B]
Get:9 http://security.debian.org stretch/updates/non-free amd64 Packages [5604 B]
Get:10 http://security.debian.org stretch/updates/non-free Translation-en [15.6 kB]
Get:11 http://httpredir.debian.org/debian stretch Release.gpg [2410 B]
Get:12 http://httpredir.debian.org/debian stretch/main amd64 Packages [7080 kB]
Get:13 http://httpredir.debian.org/debian stretch/main Translation-en [5377 kB]
Get:14 http://httpredir.debian.org/debian stretch/contrib amd64 Packages [50.7 kB]
Get:15 http://httpredir.debian.org/debian stretch/contrib Translation-en [45.8 kB]
Get:16 http://httpredir.debian.org/debian stretch/non-free amd64 Packages [78.3 kB]
Get:17 http://httpredir.debian.org/debian stretch/non-free Translation-en [80.2 kB]
Fetched 14.0 MB in 2s (4877 kB/s)
Reading package lists...
+ apt-get install --yes --no-install-recommends jq
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libjq1 libonig4
The following NEW packages will be installed:
  jq libjq1 libonig4
0 upgraded, 3 newly installed, 0 to remove and 7 not upgraded.
Need to get 329 kB of archives.
After this operation, 1158 kB of additional disk space will be used.
Get:1 http://security.debian.org stretch/updates/main amd64 libonig4 amd64 6.1.3-2+deb9u2 [147 kB]
Get:2 http://httpredir.debian.org/debian stretch/main amd64 libjq1 amd64 1.5+dfsg-1.3 [123 kB]
Get:3 http://httpredir.debian.org/debian stretch/main amd64 jq amd64 1.5+dfsg-1.3 [58.6 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 329 kB in 0s (2563 kB/s)
Selecting previously unselected package libonig4:amd64.
(Reading database ... 5683 files and directories currently installed.)
Preparing to unpack .../libonig4_6.1.3-2+deb9u2_amd64.deb ...
Unpacking libonig4:amd64 (6.1.3-2+deb9u2) ...
Selecting previously unselected package libjq1:amd64.
Preparing to unpack .../libjq1_1.5+dfsg-1.3_amd64.deb ...
Unpacking libjq1:amd64 (1.5+dfsg-1.3) ...
Selecting previously unselected package jq.
Preparing to unpack .../jq_1.5+dfsg-1.3_amd64.deb ...
Unpacking jq (1.5+dfsg-1.3) ...
Setting up libonig4:amd64 (6.1.3-2+deb9u2) ...
Setting up libjq1:amd64 (1.5+dfsg-1.3) ...
Processing triggers for libc-bin (2.24-11+deb9u4) ...
Setting up jq (1.5+dfsg-1.3) ...
+ apt-get clean
+ rm -rf /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch-updates_InRelease /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch_Release /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch_Release.gpg /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch_contrib_binary-amd64_Packages /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch_contrib_i18n_Translation-en /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch_main_binary-amd64_Packages /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch_main_i18n_Translation-en /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch_non-free_binary-amd64_Packages /var/lib/apt/lists/httpredir.debian.org_debian_dists_stretch_non-free_i18n_Translation-en /var/lib/apt/lists/lock /var/lib/apt/lists/partial /var/lib/apt/lists/security.debian.org_dists_stretch_updates_InRelease /var/lib/apt/lists/security.debian.org_dists_stretch_updates_contrib_binary-amd64_Packages /var/lib/apt/lists/security.debian.org_dists_stretch_updates_contrib_i18n_Translation-en /var/lib/apt/lists/security.debian.org_dists_stretch_updates_main_binary-amd64_Packages /var/lib/apt/lists/security.debian.org_dists_stretch_updates_main_i18n_Translation-en /var/lib/apt/lists/security.debian.org_dists_stretch_updates_non-free_binary-amd64_Packages /var/lib/apt/lists/security.debian.org_dists_stretch_updates_non-free_i18n_Translation-en /root/.bashrc /usr/share/doc/ /usr/share/doc-base/ /usr/share/man/ /tmp/*
Removing intermediate container bf87e1661675
 ---> 63f0590f3e38
Step 6/7 : ADD entrypoint.sh /
 ---> a5e279b7c390
Step 7/7 : ENTRYPOINT ["dumb-init", "/entrypoint.sh"]
 ---> Running in 815ce4ab258f
Removing intermediate container 815ce4ab258f
 ---> 23664dc863f7
Successfully built 23664dc863f7
Successfully tagged monitoring-hook:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make[1]: Leaving directory '/home/walt/git/monitoring-app/images'
walt@work:~/git/monitoring-app$ find . \! -user 1000
walt@work:~/git/monitoring-app$ 
```

</details>

<details><summary>as root</summary>

```console
walt@work:~/git/monitoring-app$ sudo -E zsh
[sudo] password for walt:
root@work:~/git/monitoring-app$ make clean
make -C watcher clean
make[1]: Entering directory '/home/walt/git/monitoring-app/watcher'
rm -rf /home/walt/git/monitoring-app/watcher/build
make[1]: Leaving directory '/home/walt/git/monitoring-app/watcher'
make -C images clean
make[1]: Entering directory '/home/walt/git/monitoring-app/images'
make -C /home/walt/git/monitoring-app/images/heapster -f Makefile clean
make[2]: Entering directory '/home/walt/git/monitoring-app/images/heapster'
rm -f build/heapster
rm -f build/eventer
make[2]: Leaving directory '/home/walt/git/monitoring-app/images/heapster'
make -C /home/walt/git/monitoring-app/images/influxdb clean
make[2]: Entering directory '/home/walt/git/monitoring-app/images/influxdb'
rm -rf build/influx*
make[2]: Leaving directory '/home/walt/git/monitoring-app/images/influxdb'
make[1]: Leaving directory '/home/walt/git/monitoring-app/images'
root@work:~/git/monitoring-app$ make package
make -C watcher
make[1]: Entering directory '/home/walt/git/monitoring-app/watcher'
mkdir -p /home/walt/git/monitoring-app/watcher/build
docker run -i --rm=true \
        --user $(id -u):$(id -g) \
        -v /home/walt/git/monitoring-app/watcher/:/gopath/src/github.com/gravitational/monitoring-app/watcher \
        -e GOCACHE=/tmp/gocache \
        -e VERSION=5.5.25-1-g9d5767b0 \
        -e COMMIT=9d5767b0b63e25c90515df1784a989a5a9960684 \
        quay.io/gravitational/debian-venti:go1.12.17-stretch \
        /bin/bash -c "make -C /gopath/src/github.com/gravitational/monitoring-app/watcher build-inside-container"
make: Entering directory '/gopath/src/github.com/gravitational/monitoring-app/watcher'
GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/gravitational/monitoring-app/watcher/vendor/github.com/gravitational/version.gitCommit=9d5767b0b63e25c90515df1784a989a5a9960684 -X github.com/gravitational/monitoring-app/watcher/vendor/github.com/gravitational/version.version=5.5.25-1-g9d5767b0 -w" -o /gopath/src/github.com/gravitational/monitoring-app/watcher/build/watcher github.com/gravitational/monitoring-app/watcher/tool/watcher
make: Leaving directory '/gopath/src/github.com/gravitational/monitoring-app/watcher'
docker build -t watcher:5.5.25-1-g9d5767b0 .
Sending build context to Docker daemon   71.3MB
Step 1/5 : FROM quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 2/5 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> 1a6c02c08dff
Step 3/5 : ADD Dockerfile /
 ---> Using cache
 ---> d2cb8f0ce4d0
Step 4/5 : ADD build/watcher /
 ---> Using cache
 ---> 06934cc6f961
Step 5/5 : ENTRYPOINT ["/usr/bin/dumb-init", "/watcher"]
 ---> Using cache
 ---> 7b32cf51f8d0
Successfully built 7b32cf51f8d0
Successfully tagged watcher:5.5.25-1-g9d5767b0
make[1]: Leaving directory '/home/walt/git/monitoring-app/watcher'
make -C images all
make[1]: Entering directory '/home/walt/git/monitoring-app/images'
make -C /home/walt/git/monitoring-app/images/heapster -e VER=v1.5.4 TARGET=heapster TARGETDIR=heapster -f /home/walt/git/monitoring-app/images/buildbox.mk
make[2]: Entering directory '/home/walt/git/monitoring-app/images/heapster'

---> BuildBox for heapster:

docker run --rm=true \
        --user $(id -u):$(id -g) \
        --volume=/home/walt/git/monitoring-app/images/heapster:/assets \
        --volume=/home/walt/git/monitoring-app/images/heapster/build:/targetdir \
        --env="TARGETDIR=/targetdir" \
        --env="VER=v1.5.4" \
        $(cat /home/walt/git/monitoring-app/images/heapster/build/.bbox.iid) \
        make -f /assets/Makefile

---> Building /targetdir/heapster

mkdir -p /gopath/src/k8s.io
cd /gopath/src/k8s.io && git clone https://github.com/kubernetes/heapster -b v1.5.4
Cloning into 'heapster'...
Note: checking out '105c0f2e84ae9dc6de5a0ce8e9dd7d15e9abf014'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

cd /gopath/src/k8s.io/heapster && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -a -installsuffix cgo --ldflags '-w' ./...
cd /gopath/src/k8s.io/heapster && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o heapster -a -installsuffix cgo --ldflags '-w' k8s.io/heapster/metrics && mv /gopath/src/k8s.io/heapster/heapster /targetdir/
cd /gopath/src/k8s.io/heapster && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o eventer -a -installsuffix cgo --ldflags '-w' k8s.io/heapster/events && mv /gopath/src/k8s.io/heapster/eventer /targetdir/
make[2]: Leaving directory '/home/walt/git/monitoring-app/images/heapster'
make -e BUILDIMAGE=monitoring-heapster:5.5.25-1-g9d5767b0 TARGETDIR=heapster make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull  -t monitoring-heapster:5.5.25-1-g9d5767b0 heapster
Sending build context to Docker daemon  75.39MB
Step 1/6 : FROM quay.io/gravitational/debian-tall:stretch
stretch: Pulling from gravitational/debian-tall
Digest: sha256:efc3b0ca6d21c7856509245fb126ddb7041e7cebeddf1312dc3908e59d600d65
Status: Image is up to date for quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 2/6 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> 1a6c02c08dff
Step 3/6 : VOLUME /var/run/heapster/hosts
 ---> Using cache
 ---> 93911dc8bec9
Step 4/6 : ADD Dockerfile /
 ---> Using cache
 ---> c206cecb405c
Step 5/6 : ADD build/heapster /heapster
 ---> Using cache
 ---> 5d6c959414e2
Step 6/6 : ENTRYPOINT ["/heapster"]
 ---> Using cache
 ---> 0745af15bdac
Successfully built 0745af15bdac
Successfully tagged monitoring-heapster:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make -C /home/walt/git/monitoring-app/images/influxdb -e VER=v1.5.2 TARGET=influxd TARGETDIR=influxdb -f /home/walt/git/monitoring-app/images/buildbox.mk
make[2]: Entering directory '/home/walt/git/monitoring-app/images/influxdb'

---> BuildBox for influxd:

docker run --rm=true \
        --user $(id -u):$(id -g) \
        --volume=/home/walt/git/monitoring-app/images/influxdb:/assets \
        --volume=/home/walt/git/monitoring-app/images/influxdb/build:/targetdir \
        --env="TARGETDIR=/targetdir" \
        --env="VER=v1.5.2" \
        $(cat /home/walt/git/monitoring-app/images/influxdb/build/.bbox.iid) \
        make -f /assets/Makefile

---> Building /targetdir/influxd

mkdir -p /gopath/src/github.com/influxdata
cd /gopath/src/github.com/influxdata && git clone https://github.com/influxdata/influxdb -b v1.5.2
Cloning into 'influxdb'...
Note: checking out '02d7d4f043b34ecb4e9b2dbec298c6f9450c2a32'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

cd /gopath/src/github.com/influxdata/influxdb && python build.py --release --platform=linux --arch=static_amd64 --branch=v1.5.2
[INFO] print_banner:
  ___       __ _          ___  ___
 |_ _|_ _  / _| |_  ___ _|   \| _ )
  | || ' \|  _| | || \ \ / |) | _ \
 |___|_||_|_| |_|\_,_/_\_\___/|___/
  Build Script

[INFO] check_environ: Checking environment...
[INFO] check_prereqs: Checking for dependencies...
[INFO] main: Moving to git branch: v1.5.2
[INFO] go_get: Downloading `gdm`...
[INFO] go_get: Retrieving dependencies with `gdm`...
[INFO] build: Starting build for linux/static_amd64...
[INFO] build: Using Go version: 1.9
[INFO] build: Using git branch: HEAD
[INFO] build: Using git commit: 02d7d4f043b34ecb4e9b2dbec298c6f9450c2a32
[INFO] build: Sending build output to: /gopath/src/github.com/influxdata/influxdb/build
[INFO] build: Using version '1.5.2' for build.
[INFO] build: Building target: influx_stress
[INFO] build: Time taken: 5.526678s
[INFO] build: Building target: influxd
[INFO] build: Time taken: 12.458795s
[INFO] build: Building target: influx_inspect
[INFO] build: Time taken: 10.483678s
[INFO] build: Building target: influx
[INFO] build: Time taken: 5.931583s
[INFO] build: Building target: influx_tsm
[INFO] build: Time taken: 11.827326s
mv /gopath/src/github.com/influxdata/influxdb/build/influxd /gopath/src/github.com/influxdata/influxdb/build/influx /targetdir/
make[2]: Leaving directory '/home/walt/git/monitoring-app/images/influxdb'
make -e BUILDIMAGE=monitoring-influxdb:5.5.25-1-g9d5767b0 TARGETDIR=influxdb make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull  -t monitoring-influxdb:5.5.25-1-g9d5767b0 influxdb
Sending build context to Docker daemon  21.12MB
Step 1/9 : FROM quay.io/gravitational/debian-tall:stretch
stretch: Pulling from gravitational/debian-tall
Digest: sha256:efc3b0ca6d21c7856509245fb126ddb7041e7cebeddf1312dc3908e59d600d65
Status: Image is up to date for quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 2/9 : ENV INFLUXDB_HOME /influxdb
 ---> Using cache
 ---> 741a2021987e
Step 3/9 : ENV PATH $INFLUXDB_HOME:$PATH
 ---> Using cache
 ---> 32b84135b3ab
Step 4/9 : EXPOSE 8083 8086 8086/udp 8088 2003 4242 25826
 ---> Using cache
 ---> 31706f76a12e
Step 5/9 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> b91b28cd88fe
Step 6/9 : RUN set -ex && mkdir -p $INFLUXDB_HOME /data /logs
 ---> Using cache
 ---> e1f78fee4e13
Step 7/9 : ADD build/influx* $INFLUXDB_HOME/
 ---> Using cache
 ---> c88fe26a66c4
Step 8/9 : VOLUME ["/data"]
 ---> Using cache
 ---> 77e0b4b5fa0d
Step 9/9 : VOLUME ["/logs"]
 ---> Using cache
 ---> 1eb878b5794c
Successfully built 1eb878b5794c
Successfully tagged monitoring-influxdb:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make -e BUILDIMAGE=monitoring-grafana:5.5.25-1-g9d5767b0 EXTRA_ARGS="--build-arg GRAFANA_VERSION=6.7.4" TARGETDIR=grafana make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull --build-arg GRAFANA_VERSION=6.7.4 -t monitoring-grafana:5.5.25-1-g9d5767b0 grafana
Sending build context to Docker daemon  163.8kB
Step 1/20 : FROM debian:stretch-slim
stretch-slim: Pulling from library/debian
Digest: sha256:0ee501c41db93e0dc3b9b3851d3995db6ec8c66f71ef8a9fd0f52e5aa5abc2e1
Status: Image is up to date for debian:stretch-slim
 ---> eda1325acaaa
Step 2/20 : ARG GRAFANA_VERSION
 ---> Using cache
 ---> 033140b37c26
Step 3/20 : ARG GRAFANA_TGZ="https://dl.grafana.com/oss/release/grafana-${GRAFANA_VERSION}.linux-amd64.tar.gz"
 ---> Using cache
 ---> 3a273f409f60
Step 4/20 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> f3849a266aac
Step 5/20 : RUN set -ex && apt-get update && apt-get install -qq -y tar &&     apt-get autoremove -y &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 1ddefb6e31b5
Step 6/20 : ADD ${GRAFANA_TGZ} /tmp/grafana.tar.gz
Downloading [==================================================>]  65.08MB/65.08MB

 ---> Using cache
 ---> 6e7e405c67f2
Step 7/20 : RUN set -ex && mkdir /tmp/grafana && tar xfvz /tmp/grafana.tar.gz --strip-components=1 -C /tmp/grafana
 ---> Using cache
 ---> 5c2c2d0315cd
Step 8/20 : FROM debian:stretch-slim
stretch-slim: Pulling from library/debian
Digest: sha256:0ee501c41db93e0dc3b9b3851d3995db6ec8c66f71ef8a9fd0f52e5aa5abc2e1
Status: Image is up to date for debian:stretch-slim
 ---> eda1325acaaa
Step 9/20 : ARG GF_UID="472"
 ---> Using cache
 ---> 7c32f1b004dd
Step 10/20 : ARG GF_GID="472"
 ---> Using cache
 ---> 4109a57b1d8f
Step 11/20 : ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin     GF_PATHS_CONFIG="/etc/grafana/grafana.ini"     GF_PATHS_DATA="/var/lib/grafana"     GF_PATHS_HOME="/usr/share/grafana"     GF_PATHS_LOGS="/var/log/grafana"     GF_PATHS_PLUGINS="/var/lib/grafana/plugins"     GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
 ---> Using cache
 ---> faa1bd335bf3
Step 12/20 : WORKDIR $GF_PATHS_HOME
 ---> Using cache
 ---> f0781131748d
Step 13/20 : RUN set -ex && apt-get update && apt-get install -qq -y libfontconfig ca-certificates dumb-init &&     apt-get autoremove -y &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 0263675a19fd
Step 14/20 : COPY --from=0 /tmp/grafana "$GF_PATHS_HOME"
 ---> Using cache
 ---> b0063cec1820
Step 15/20 : COPY rootfs/ /
 ---> Using cache
 ---> b4f42b66cc30
Step 16/20 : RUN set -ex && groupadd -r -g $GF_GID grafana &&     useradd -r -u $GF_UID -g grafana grafana &&     mkdir -p "$GF_PATHS_PROVISIONING/datasources"              "$GF_PATHS_PROVISIONING/dashboards"              "$GF_PATHS_PROVISIONING/notifiers"              "$GF_PATHS_LOGS"              "$GF_PATHS_PLUGINS"              "$GF_PATHS_DATA" &&     cp "$GF_PATHS_HOME/conf/sample.ini" "$GF_PATHS_CONFIG" &&     cp "$GF_PATHS_HOME/conf/ldap.toml" /etc/grafana/ldap.toml &&     chown -R grafana:grafana "$GF_PATHS_DATA" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" &&     chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING"
 ---> Using cache
 ---> b68bc8cbce17
Step 17/20 : EXPOSE 3000
 ---> Using cache
 ---> 59963438a32a
Step 18/20 : COPY ./run.sh /run.sh
 ---> Using cache
 ---> 38d869a762d0
Step 19/20 : USER grafana
 ---> Using cache
 ---> 1c95eeac2398
Step 20/20 : ENTRYPOINT [  "/usr/bin/dumb-init", "/run.sh" ]
 ---> Using cache
 ---> d84336c0f8c3
Successfully built d84336c0f8c3
Successfully tagged monitoring-grafana:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make -e BUILDIMAGE=monitoring-kapacitor:5.5.25-1-g9d5767b0 EXTRA_ARGS="--build-arg KAPACITOR_VERSION=1.5.0" TARGETDIR=kapacitor make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull --build-arg KAPACITOR_VERSION=1.5.0 -t monitoring-kapacitor:5.5.25-1-g9d5767b0 kapacitor
Sending build context to Docker daemon  6.144kB
Step 1/13 : FROM quay.io/gravitational/debian-grande:stretch as downloader
stretch: Pulling from gravitational/debian-grande
Digest: sha256:ad2690fdced0d68b04ca59723e5e83cb430380f246c1d0605811bcfbfa36a9c9
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> cff1f7cdd5bf
Step 2/13 : ARG KAPACITOR_VERSION
 ---> Using cache
 ---> ecc8b26603ab
Step 3/13 : RUN set -ex && apt-get update &&     apt-get install -y curl tar &&     curl -sSL https://dl.influxdata.com/kapacitor/releases/kapacitor-${KAPACITOR_VERSION}_linux_amd64.tar.gz -o /kapacitor.tar.gz &&     tar xzf /kapacitor.tar.gz --strip-components=2
 ---> Using cache
 ---> f278b2e08d68
Step 4/13 : FROM quay.io/gravitational/debian-tall:stretch
stretch: Pulling from gravitational/debian-tall
Digest: sha256:efc3b0ca6d21c7856509245fb126ddb7041e7cebeddf1312dc3908e59d600d65
Status: Image is up to date for quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 5/13 : COPY --from=downloader /usr/bin/kapacitor /usr/bin/kapacitord /usr/bin/tickfmt /usr/bin/
 ---> Using cache
 ---> c1372692764c
Step 6/13 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> 633740961df3
Step 7/13 : EXPOSE 9092
 ---> Using cache
 ---> a201728b7b62
Step 8/13 : VOLUME /var/lib/kapacitor
 ---> Using cache
 ---> 61b63fa780ff
Step 9/13 : COPY kapacitor.conf /etc/kapacitor/kapacitor.conf
 ---> Using cache
 ---> 8adac577c89b
Step 10/13 : COPY entrypoint.sh /entrypoint.sh
 ---> Using cache
 ---> c617b44d569b
Step 11/13 : COPY loadalerts.sh /loadalerts.sh
 ---> Using cache
 ---> 7d3b02ac5c07
Step 12/13 : ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 ---> Using cache
 ---> 2f3f3916abaf
Step 13/13 : CMD ["/entrypoint.sh"]
 ---> Using cache
 ---> 8b375435daa3
Successfully built 8b375435daa3
Successfully tagged monitoring-kapacitor:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make -e BUILDIMAGE=monitoring-telegraf:5.5.25-1-g9d5767b0 EXTRA_ARGS="--build-arg TELEGRAF_VERSION=1.11.5" TARGETDIR=telegraf make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull --build-arg TELEGRAF_VERSION=1.11.5 -t monitoring-telegraf:5.5.25-1-g9d5767b0 telegraf
Sending build context to Docker daemon   21.5kB
Step 1/10 : FROM quay.io/gravitational/debian-grande:stretch AS downloader
stretch: Pulling from gravitational/debian-grande
Digest: sha256:ad2690fdced0d68b04ca59723e5e83cb430380f246c1d0605811bcfbfa36a9c9
Status: Image is up to date for quay.io/gravitational/debian-grande:stretch
 ---> cff1f7cdd5bf
Step 2/10 : ARG TELEGRAF_VERSION
 ---> Using cache
 ---> 8439393f4d39
Step 3/10 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> 58f61499029a
Step 4/10 : ENV DEBIAN_FRONTEND=noninteractive     TERM=xterm
 ---> Using cache
 ---> c5fa5ade5c10
Step 5/10 : RUN set -ex && apt-get update &&     apt-get install --yes --no-install-recommends curl tar &&     curl -sSL https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_amd64.tar.gz -o /telegraf.tar.gz &&     tar xzf /telegraf.tar.gz --strip-components=2
 ---> Using cache
 ---> 32ba40cf0f4e
Step 6/10 : FROM quay.io/gravitational/debian-tall:stretch
stretch: Pulling from gravitational/debian-tall
Digest: sha256:efc3b0ca6d21c7856509245fb126ddb7041e7cebeddf1312dc3908e59d600d65
Status: Image is up to date for quay.io/gravitational/debian-tall:stretch
 ---> 0db8b20cf084
Step 7/10 : COPY --from=downloader /usr/bin/telegraf /usr/bin/telegraf
 ---> Using cache
 ---> 2ffa723f8458
Step 8/10 : ADD rootfs/ /
 ---> Using cache
 ---> dc42f662f298
Step 9/10 : ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 ---> Using cache
 ---> f6982c2e6416
Step 10/10 : CMD ["/usr/bin/telegraf", "--config", "/etc/telegraf/telegraf.conf"]
 ---> Using cache
 ---> 5a2d72bad943
Successfully built 5a2d72bad943
Successfully tagged monitoring-telegraf:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
if [ -z "5525-1-g9d5767b0" ]; then \
  echo "CHANGESET is not set"; exit 1; \
fi;
make -e BUILDIMAGE=monitoring-hook:5.5.25-1-g9d5767b0 EXTRA_ARGS="--build-arg CHANGESET=monitoring-5525-1-g9d5767b0" TARGETDIR=hook make-docker-image
make[2]: Entering directory '/home/walt/git/monitoring-app/images'
docker build --pull --build-arg CHANGESET=monitoring-5525-1-g9d5767b0 -t monitoring-hook:5.5.25-1-g9d5767b0 hook
Sending build context to Docker daemon  8.192kB
Step 1/7 : FROM quay.io/gravitational/rig:5.5.8
5.5.8: Pulling from gravitational/rig
Digest: sha256:a73b52308b045664e93ae9fe7e87e2a7d0f71a128914f2a2b1f8f225f4c6c618
Status: Image is up to date for quay.io/gravitational/rig:5.5.8
 ---> 3003333a77af
Step 2/7 : RUN set -ex && test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 ---> Using cache
 ---> ff1c7b4bc50c
Step 3/7 : ARG CHANGESET
 ---> Using cache
 ---> 6b14eba95d85
Step 4/7 : ENV RIG_CHANGESET $CHANGESET
 ---> Using cache
 ---> 2411cab71502
Step 5/7 : RUN set -ex && apt-get update &&     apt-get install --yes --no-install-recommends jq &&     apt-get clean &&     rm -rf         /var/lib/apt/lists/*         ~/.bashrc         /usr/share/doc/         /usr/share/doc-base/         /usr/share/man/         /tmp/*
 ---> Using cache
 ---> 63f0590f3e38
Step 6/7 : ADD entrypoint.sh /
 ---> Using cache
 ---> a5e279b7c390
Step 7/7 : ENTRYPOINT ["dumb-init", "/entrypoint.sh"]
 ---> Using cache
 ---> 23664dc863f7
Successfully built 23664dc863f7
Successfully tagged monitoring-hook:5.5.25-1-g9d5767b0
make[2]: Leaving directory '/home/walt/git/monitoring-app/images'
make[1]: Leaving directory '/home/walt/git/monitoring-app/images'
root@work:~/git/monitoring-app$ exit
walt@work:~/git/monitoring-app$ find . \! -user 1000
./images/influxdb/build/influx
./images/influxdb/build/influxd
./images/heapster/build/heapster
./images/heapster/build/eventer
./watcher/build
./watcher/build/watcher

```

</detals>