### PR TITLE
[6.0] bump rigging to 6.1.5

### DIFF
--- a/images/hook/Dockerfile
+++ b/images/hook/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/gravitational/rig:6.0.3
+FROM quay.io/gravitational/rig:6.1.2
 
 # Ensure nsswitch is set so localhost will be resolved locally
 # https://github.com/gravitational/gravity/issues/1046


### PR DESCRIPTION
I realize this is a bump from 6.0 -> 6.1, but 6.1 is our LTS release but the monitoring-app was left on 6.0. So use rigging from the LTS release. 