### PR TITLE
Use new ports for controller-manager and scheduler

### DIFF
--- a/resources/custom-values.yaml
+++ b/resources/custom-values.yaml
@@ -318,6 +318,10 @@ prometheus:
         authorization:
           type: Bearer
           credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        tls_config:
+          ca_file: /var/state/root.cert
+          cert_file: /var/state/scheduler.cert
+          key_file: /var/state/scheduler.key
       - job_name: kube-controller-manager
         scheme: https
         kubernetes_sd_configs:
@@ -349,6 +353,10 @@ prometheus:
         authorization:
           type: Bearer
           credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        tls_config:
+          ca_file: /var/state/root.cert
+          cert_file: /var/state/scheduler.cert
+          key_file: /var/state/scheduler.key
         metric_relabel_configs:
           - action: labeldrop
             regex: etcd_(debugging|disk|request|server).*    


### PR DESCRIPTION
In the latest(can't find exactly in which one, but it is already present in 1.19) controller-manager and scheduler insecure ports were deleted.