### PR TITLE
[AOP-3718] Don't apply label filters to selectors

### DIFF
--- a/resources/custom-values.yaml
+++ b/resources/custom-values.yaml
@@ -244,6 +244,9 @@ prometheus:
     volumeMounts:
       - name: secrets
         mountPath: /var/state
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
     additionalScrapeConfigs:
       - job_name: etcd
         kubernetes_sd_configs:


### PR DESCRIPTION
By default helm chart searches for Prometheus rules/servicemonitors with the label containing release name, which does not make sense as the use of the platform should search in code or in resource definition which labels to apply to its own custom rules.
