### PR TITLE
Fix watcher pointing to the wrong services

### DIFF
--- a/resources/charts/watcher/templates/role.yaml
+++ b/resources/charts/watcher/templates/role.yaml
@@ -36,7 +36,7 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - alertmanager-main
+      - alertmanager-monitoring-kube-prometheus-alertmanager
   - apiGroups:
       - monitoring.coreos.com
     verbs:

--- a/resources/custom-values.yaml
+++ b/resources/custom-values.yaml
@@ -325,6 +325,7 @@ prometheus:
           ca_file: /var/state/root.cert
           cert_file: /var/state/scheduler.cert
           key_file: /var/state/scheduler.key
+          insecure_skip_verify: true
       - job_name: kube-controller-manager
         scheme: https
         kubernetes_sd_configs:
@@ -360,9 +361,10 @@ prometheus:
           ca_file: /var/state/root.cert
           cert_file: /var/state/scheduler.cert
           key_file: /var/state/scheduler.key
+          insecure_skip_verify: true
         metric_relabel_configs:
           - action: labeldrop
-            regex: etcd_(debugging|disk|request|server).*    
+            regex: etcd_(debugging|disk|request|server).*
     securityContext:
       runAsGroup: 2000
       runAsNonRoot: true

--- a/resources/custom-values.yaml
+++ b/resources/custom-values.yaml
@@ -325,7 +325,6 @@ prometheus:
           ca_file: /var/state/root.cert
           cert_file: /var/state/scheduler.cert
           key_file: /var/state/scheduler.key
-          insecure_skip_verify: true
       - job_name: kube-controller-manager
         scheme: https
         kubernetes_sd_configs:
@@ -361,7 +360,6 @@ prometheus:
           ca_file: /var/state/root.cert
           cert_file: /var/state/scheduler.cert
           key_file: /var/state/scheduler.key
-          insecure_skip_verify: true
         metric_relabel_configs:
           - action: labeldrop
             regex: etcd_(debugging|disk|request|server).*

--- a/watcher/lib/resources/resources.go
+++ b/watcher/lib/resources/resources.go
@@ -395,4 +395,4 @@ var prometheusRuleLabels = map[string]string{
 var alertmanagerConfigFilename = "alertmanager.yaml"
 
 // alertmanagerSecretName is the name of the secret with Alertmanager configuration.
-var alertmanagerSecretName = "alertmanager-main"
+var alertmanagerSecretName = "alertmanager-monitoring-kube-prometheus-alertmanager"


### PR DESCRIPTION
After migration to Helm charts the name of the services changed and that broke the alerts watcher.
+ skip tls verification for kube-scheduler and controller-manager.