### PR TITLE
[AOP-3772] Bump dependency charts versions

### DIFF
--- a/resources/charts/kube-prometheus-stack/Chart.lock
+++ b/resources/charts/kube-prometheus-stack/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 3.4.1
+  version: 3.4.2
 - name: prometheus-node-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 2.0.1
+  version: 2.0.4
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.14.1
-digest: sha256:40b98c939754f411462704dc80ddc365dd89243df698558bdc03374fa0bfa175
-generated: "2021-07-22T11:16:45.549421239+02:00"
+  version: 6.14.2
+digest: sha256:a13ebf3f5e6c0ce2f539ea06173fe6afa772d668ee5fa9c840ff95232f443b48
+generated: "2021-11-17T14:34:41.588686-05:00"

--- a/resources/charts/kube-prometheus-stack/charts/grafana/Chart.yaml
+++ b/resources/charts/kube-prometheus-stack/charts/grafana/Chart.yaml
@@ -19,4 +19,4 @@ name: grafana
 sources:
 - https://github.com/grafana/grafana
 type: application
-version: 6.14.1
+version: 6.14.2

--- a/resources/charts/kube-prometheus-stack/charts/grafana/templates/_helpers.tpl
+++ b/resources/charts/kube-prometheus-stack/charts/grafana/templates/_helpers.tpl
@@ -118,13 +118,6 @@ new password and use it.
 {{- end -}}
 
 {{/*
-Get KubeVersion removing pre-release information.
-*/}}
-{{- define "grafana.kubeVersion" -}}
-  {{- default .Capabilities.KubeVersion.Version (regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+" .Capabilities.KubeVersion.Version) -}}
-{{- end -}}
-
-{{/*
 Return the appropriate apiVersion for rbac.
 */}}
 {{- define "grafana.rbac.apiVersion" -}}
@@ -139,7 +132,7 @@ Return the appropriate apiVersion for rbac.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "grafana.ingress.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "grafana.kubeVersion" .)) -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
       {{- print "networking.k8s.io/v1" -}}
   {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
     {{- print "networking.k8s.io/v1beta1" -}}
@@ -159,12 +152,12 @@ Return if ingress is stable.
 Return if ingress supports ingressClassName.
 */}}
 {{- define "grafana.ingress.supportsIngressClassName" -}}
-  {{- or (eq (include "grafana.ingress.isStable" .) "true") (and (eq (include "grafana.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "grafana.kubeVersion" .))) -}}
+  {{- or (eq (include "grafana.ingress.isStable" .) "true") (and (eq (include "grafana.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}
 
 {{/*
 Return if ingress supports pathType.
 */}}
 {{- define "grafana.ingress.supportsPathType" -}}
-  {{- or (eq (include "grafana.ingress.isStable" .) "true") (and (eq (include "grafana.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18.x" (include "grafana.kubeVersion" .))) -}}
+  {{- or (eq (include "grafana.ingress.isStable" .) "true") (and (eq (include "grafana.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}

--- a/resources/charts/kube-prometheus-stack/charts/kube-state-metrics/Chart.yaml
+++ b/resources/charts/kube-prometheus-stack/charts/kube-state-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.1.0
+appVersion: 2.1.1
 description: Install kube-state-metrics to generate and expose cluster-level metrics
 home: https://github.com/kubernetes/kube-state-metrics/
 keywords:
@@ -16,4 +16,4 @@ name: kube-state-metrics
 sources:
 - https://github.com/kubernetes/kube-state-metrics/
 type: application
-version: 3.4.1
+version: 3.4.2

--- a/resources/charts/kube-prometheus-stack/charts/kube-state-metrics/values.yaml
+++ b/resources/charts/kube-prometheus-stack/charts/kube-state-metrics/values.yaml
@@ -2,7 +2,7 @@
 prometheusScrape: true
 image:
   repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
-  tag: v2.1.0
+  tag: v2.1.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/resources/charts/kube-prometheus-stack/charts/prometheus-node-exporter/Chart.yaml
+++ b/resources/charts/kube-prometheus-stack/charts/prometheus-node-exporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.2.0
+appVersion: 1.2.2
 description: A Helm chart for prometheus node-exporter
 home: https://github.com/prometheus/node_exporter/
 keywords:
@@ -15,4 +15,4 @@ name: prometheus-node-exporter
 sources:
 - https://github.com/prometheus/node_exporter/
 type: application
-version: 2.0.1
+version: 2.0.4

--- a/resources/charts/kube-prometheus-stack/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/resources/charts/kube-prometheus-stack/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -129,7 +129,7 @@ spec:
           {{- end }}
 {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
-      hostPID: true
+      hostPID: {{ .Values.hostPID }}
 {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/resources/charts/kube-prometheus-stack/charts/prometheus-node-exporter/values.yaml
+++ b/resources/charts/kube-prometheus-stack/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/prometheus/node-exporter
-  tag: v1.2.0
+  tag: v1.2.2
   pullPolicy: IfNotPresent
 
 service:
@@ -84,6 +84,9 @@ endpoints: []
 
 # Expose the service to the host network
 hostNetwork: true
+
+# Share the host process ID namespace
+hostPID: true
 
 ## If true, node-exporter pods mounts host / at /host/root
 ##


### PR DESCRIPTION
All dependency charts were updated to their patch version, which I assume is safe enough.
Mostly the bump happened just for the node-exporter chart to fix the issue above on AWS instances, but `help dep update` bumps everything automatically to patch versions and I decided to leave them updated.
```
level=error ts=2021-11-17T16:43:21.407Z caller=collector.go:169 msg="collector failed" name=nvme duration_seconds=2.7749e-05 err="error obtaining NVMe class info: failed to list NVMe devices at \"/host/sys/class/nvme\": open /host/sys/class/nvme: no such file or directory"
```