### PR TITLE
[6.0.x] Upgrade kube-rbac-proxy and kube-state-metrics

### DIFF
--- a/resources/prometheus/kube-state-metrics-clusterRole.yaml
+++ b/resources/prometheus/kube-state-metrics-clusterRole.yaml
@@ -35,6 +35,7 @@ rules:
   - daemonsets
   - deployments
   - replicasets
+  - ingresses
   verbs:
   - list
   - watch
@@ -79,6 +80,36 @@ rules:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/resources/prometheus/kube-state-metrics-deployment.yaml
+++ b/resources/prometheus/kube-state-metrics-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - --secure-listen-address=:8443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:8081/
-        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.6.0
         name: kube-rbac-proxy-main
         ports:
         - containerPort: 8443
@@ -41,7 +41,7 @@ spec:
         - --secure-listen-address=:9443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:8082/
-        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.6.0
         name: kube-rbac-proxy-self
         ports:
         - containerPort: 9443
@@ -58,7 +58,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        image: quay.io/coreos/kube-state-metrics:v1.9.2
         name: kube-state-metrics
         resources:
           limits:

--- a/resources/prometheus/node-exporter-daemonset.yaml
+++ b/resources/prometheus/node-exporter-daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.6.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100


### PR DESCRIPTION
## Description
Upgrades `kube-rbac-proxy` from `v0.4.1` -> `v0.6.0`. 
Upgrades `kube-state-metrics` from `v1.5.0` -> `v1.9.2`
Addresses https://github.com/gravitational/gravity/issues/2702

[kube-rbac-proxy changes](https://github.com/brancz/kube-rbac-proxy/blob/master/CHANGELOG.md)
<details>

- v0.5.0
  - Move from glog to klog for logging
- v0.6.0
  - Use gcr.io/distroless/static as base image instead of alpine
</details>

[kube-state-metrics changes](https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md)
<details>

- v1.7.0
  - Use appsv1 apigroup for ReplicaSet
  - Use distroless/static as base image to further reduce image size
  - Return standardized text for health endpoint
- v1.7.2
  - Revert "add kube_*_annotations metrics for all objects"
  - Remove kube_namespace_annotations metric
- v1.8.0
  - Makefile: Remove tmpdir after container build
- v1.8.0-rc.1
  - Pin go version to go mod artifact file
- v1.9.0-rc.0
  - Add tools as go modules
</details>
