### PR TITLE
[7.0.x] Upgrade kube-rbac-proxy

### DIFF
--- a/resources/prometheus/kube-state-metrics-deployment.yaml
+++ b/resources/prometheus/kube-state-metrics-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - --secure-listen-address=:8443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:8081/
-        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.6.0
         name: kube-rbac-proxy-main
         ports:
         - containerPort: 8443
@@ -41,7 +41,7 @@ spec:
         - --secure-listen-address=:9443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:8082/
-        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.6.0
         name: kube-rbac-proxy-self
         ports:
         - containerPort: 9443

--- a/resources/prometheus/node-exporter-daemonset.yaml
+++ b/resources/prometheus/node-exporter-daemonset.yaml
@@ -55,7 +55,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.6.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 9100


### PR DESCRIPTION
## Description
Upgrades `kube-rbac-proxy` from `v0.4.1` -> `v0.6.0`.
Addresses https://github.com/gravitational/gravity/issues/2702

[kube-rbac-proxy changes](https://github.com/brancz/kube-rbac-proxy/blob/master/CHANGELOG.md)
<details>

- v0.5.0
  - Move from glog to klog for logging
- v0.6.0
  - Use gcr.io/distroless/static as base image instead of alpine
</details>